### PR TITLE
Refactor codebase to wpcs standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,40 @@ pnpm dev
 ```
 
 Your app template should now be running on [localhost:3000](http://localhost:3000/).
+
+### WordPress Coding Standards (WPCS)
+
+The `wp-bitcoin-newsletter` plugin in this repo is aligned with WPCS and includes a `phpcs.xml.dist`.
+
+- Local run (with PHP and Composer):
+
+```bash
+cd wp-bitcoin-newsletter
+composer install
+./vendor/bin/phpcs -p
+./vendor/bin/phpcbf -p
+```
+
+- Without Composer, use a global PHPCS installation:
+
+```bash
+phpcs --standard=WordPress --report=full wp-bitcoin-newsletter
+```
+
+- Suggested CI (GitHub Actions):
+
+```yaml
+name: PHPCS
+on: [push, pull_request]
+jobs:
+  phpcs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          tools: composer
+      - run: cd wp-bitcoin-newsletter && composer install --no-interaction --no-progress
+      - run: cd wp-bitcoin-newsletter && ./vendor/bin/phpcs -p
+```

--- a/wp-bitcoin-newsletter/phpcs.xml.dist
+++ b/wp-bitcoin-newsletter/phpcs.xml.dist
@@ -33,7 +33,7 @@
     <rule ref="WordPress.WP.I18n"/>
 
     <!-- Allow PSR-4 class filenames to avoid conflicts with our autoloader -->
-    <exclude name="WordPress.Files.FileName"/>
-    <exclude name="Squiz.Classes.ClassFileName"/>
+    <rule ref="WordPress.Files.FileName"><severity>0</severity></rule>
+    <rule ref="Squiz.Classes.ClassFileName"><severity>0</severity></rule>
 </ruleset>
 

--- a/wp-bitcoin-newsletter/phpcs.xml.dist
+++ b/wp-bitcoin-newsletter/phpcs.xml.dist
@@ -31,5 +31,9 @@
     </rule>
 
     <rule ref="WordPress.WP.I18n"/>
+
+    <!-- Allow PSR-4 class filenames to avoid conflicts with our autoloader -->
+    <exclude name="WordPress.Files.FileName"/>
+    <exclude name="Squiz.Classes.ClassFileName"/>
 </ruleset>
 

--- a/wp-bitcoin-newsletter/phpcs.xml.dist
+++ b/wp-bitcoin-newsletter/phpcs.xml.dist
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<ruleset name="WP Bitcoin Newsletter">
+    <description>PHPCS rules for WP Bitcoin Newsletter plugin aligned with WPCS.</description>
+
+    <rule ref="WordPress" />
+    <rule ref="WordPress-Extra" />
+    <rule ref="WordPress-Docs" />
+
+    <config name="testVersion" value="7.4-"/>
+    <config name="minimum_supported_wp_version" value="5.8"/>
+
+    <file>wp-bitcoin-newsletter.php</file>
+    <file>src</file>
+
+    <exclude-pattern>vendor/*</exclude-pattern>
+    <exclude-pattern>assets/*</exclude-pattern>
+    <exclude-pattern>*.min.js</exclude-pattern>
+
+    <arg name="colors"/>
+    <arg value="p"/>
+    <arg name="extensions" value="php"/>
+
+    <rule ref="Squiz.WhiteSpace.OperatorSpacing" />
+    <rule ref="Generic.PHP.DisallowShortOpenTag" />
+    <rule ref="Generic.PHP.RequireStrictTypes" severity="0" />
+
+    <rule ref="WordPress.DB.DirectDatabaseQuery">
+        <properties>
+            <property name="allow" type="array" value="wpdb::prepare, $wpdb->insert, $wpdb->update, $wpdb->get_row, $wpdb->get_results" />
+        </properties>
+    </rule>
+
+    <rule ref="WordPress.WP.I18n"/>
+</ruleset>
+

--- a/wp-bitcoin-newsletter/src/Admin/Settings.php
+++ b/wp-bitcoin-newsletter/src/Admin/Settings.php
@@ -1,4 +1,10 @@
 <?php
+declare(strict_types=1);
+/**
+ * Admin settings.
+ *
+ * @package wp-bitcoin-newsletter
+ */
 
 namespace WpBitcoinNewsletter\Admin;
 

--- a/wp-bitcoin-newsletter/src/Admin/Settings.php
+++ b/wp-bitcoin-newsletter/src/Admin/Settings.php
@@ -10,10 +10,10 @@ class Settings {
     public const OPTION_KEY = 'wpbn_settings';
 
     public static function register(): void {
-        add_action( 'admin_init', [ __CLASS__, 'registerSettings' ] );
+        add_action( 'admin_init', [ __CLASS__, 'register_settings' ] );
     }
 
-    public static function getSettings(): array {
+    public static function get_settings(): array {
         $defaults = [
             'payment_provider'      => 'coinsnap',
             'default_amount'        => 21,
@@ -43,7 +43,7 @@ class Settings {
         return array_merge( $defaults, $opts );
     }
 
-    public static function registerSettings(): void {
+    public static function register_settings(): void {
         register_setting(
             'wpbn_settings_group',
             self::OPTION_KEY,
@@ -66,7 +66,7 @@ class Settings {
             'payment_provider',
             __( 'Default Payment Provider', 'wpbn' ),
             function () {
-                $s = self::getSettings();
+                $s = self::get_settings();
                 echo '<select name="' . esc_attr( self::OPTION_KEY ) . '[payment_provider]">';
                 foreach ( [
                     'coinsnap' => 'Coinsnap',
@@ -84,7 +84,7 @@ class Settings {
             'default_amount',
             __( 'Default Amount', 'wpbn' ),
             function () {
-                $s = self::getSettings();
+                $s = self::get_settings();
                 echo '<input type="number" min="1" name="' . esc_attr( self::OPTION_KEY ) . '[default_amount]" value="' . esc_attr( (string) $s['default_amount'] ) . '" />';
             },
             'wpbn-settings',
@@ -95,7 +95,7 @@ class Settings {
             'default_currency',
             __( 'Default Currency', 'wpbn' ),
             function () {
-                $s = self::getSettings();
+                $s = self::get_settings();
                 echo '<select name="' . esc_attr( self::OPTION_KEY ) . '[default_currency]">';
                 foreach ( [ 'SATS', 'USD', 'EUR', 'CHF', 'JPY' ] as $cur ) {
                     echo '<option value="' . esc_attr( $cur ) . '" ' . selected( $cur, $s['default_currency'], false ) . '>' . esc_html( $cur ) . '</option>';
@@ -111,7 +111,7 @@ class Settings {
             'coinsnap_api_key',
             __( 'Coinsnap API Key', 'wpbn' ),
             function () {
-                $s = self::getSettings();
+                $s = self::get_settings();
                 echo '<input type="text" class="regular-text" name="' . esc_attr( self::OPTION_KEY ) . '[coinsnap_api_key]" value="' . esc_attr( $s['coinsnap_api_key'] ) . '" />';
             },
             'wpbn-settings',
@@ -121,7 +121,7 @@ class Settings {
             'coinsnap_store_id',
             __( 'Coinsnap Store ID', 'wpbn' ),
             function () {
-                $s = self::getSettings();
+                $s = self::get_settings();
                 echo '<input type="text" class="regular-text" name="' . esc_attr( self::OPTION_KEY ) . '[coinsnap_store_id]" value="' . esc_attr( $s['coinsnap_store_id'] ) . '" />';
             },
             'wpbn-settings',
@@ -131,7 +131,7 @@ class Settings {
             'coinsnap_api_base',
             __( 'Coinsnap API Base', 'wpbn' ),
             function () {
-                $s = self::getSettings();
+                $s = self::get_settings();
                 echo '<input type="url" class="regular-text" placeholder="https://app.coinsnap.org" name="' . esc_attr( self::OPTION_KEY ) . '[coinsnap_api_base]" value="' . esc_attr( $s['coinsnap_api_base'] ) . '" />';
             },
             'wpbn-settings',
@@ -141,7 +141,7 @@ class Settings {
             'coinsnap_webhook_secret',
             __( 'Coinsnap Webhook Secret', 'wpbn' ),
             function () {
-                $s = self::getSettings();
+                $s = self::get_settings();
                 echo '<input type="text" class="regular-text" name="' . esc_attr( self::OPTION_KEY ) . '[coinsnap_webhook_secret]" value="' . esc_attr( $s['coinsnap_webhook_secret'] ) . '" />';
             },
             'wpbn-settings',
@@ -153,7 +153,7 @@ class Settings {
             'btcpay_host',
             __( 'BTCPay Host', 'wpbn' ),
             function () {
-                $s = self::getSettings();
+                $s = self::get_settings();
                 echo '<input type="url" class="regular-text" placeholder="https://your-btcpay.example" name="' . esc_attr( self::OPTION_KEY ) . '[btcpay_host]" value="' . esc_attr( $s['btcpay_host'] ) . '" />';
             },
             'wpbn-settings',
@@ -163,7 +163,7 @@ class Settings {
             'btcpay_api_key',
             __( 'BTCPay API Key', 'wpbn' ),
             function () {
-                $s = self::getSettings();
+                $s = self::get_settings();
                 echo '<input type="text" class="regular-text" name="' . esc_attr( self::OPTION_KEY ) . '[btcpay_api_key]" value="' . esc_attr( $s['btcpay_api_key'] ) . '" />';
             },
             'wpbn-settings',
@@ -173,7 +173,7 @@ class Settings {
             'btcpay_store_id',
             __( 'BTCPay Store ID', 'wpbn' ),
             function () {
-                $s = self::getSettings();
+                $s = self::get_settings();
                 echo '<input type="text" class="regular-text" name="' . esc_attr( self::OPTION_KEY ) . '[btcpay_store_id]" value="' . esc_attr( $s['btcpay_store_id'] ) . '" />';
             },
             'wpbn-settings',
@@ -183,7 +183,7 @@ class Settings {
             'btcpay_webhook_secret',
             __( 'BTCPay Webhook Secret', 'wpbn' ),
             function () {
-                $s = self::getSettings();
+                $s = self::get_settings();
                 echo '<input type="text" class="regular-text" name="' . esc_attr( self::OPTION_KEY ) . '[btcpay_webhook_secret]" value="' . esc_attr( $s['btcpay_webhook_secret'] ) . '" />';
             },
             'wpbn-settings',
@@ -195,7 +195,7 @@ class Settings {
             'newsletter_provider',
             __( 'Provider', 'wpbn' ),
             function () {
-                $s = self::getSettings();
+                $s = self::get_settings();
                 echo '<select name="' . esc_attr( self::OPTION_KEY ) . '[newsletter_provider]">';
                 foreach ( [
                     'wpdb'      => __( 'WP Database (internal only)', 'wpbn' ),
@@ -216,7 +216,7 @@ class Settings {
             'mailpoet_list_id',
             __( 'MailPoet List ID', 'wpbn' ),
             function () {
-                $s = self::getSettings();
+                $s = self::get_settings();
                 echo '<input type="text" class="regular-text" name="' . esc_attr( self::OPTION_KEY ) . '[mailpoet_list_id]" value="' . esc_attr( $s['mailpoet_list_id'] ) . '" />';
             },
             'wpbn-settings',
@@ -313,7 +313,7 @@ class Settings {
         return $out;
     }
 
-    public static function renderPage(): void {
+    public static function render_page(): void {
         echo '<div class="wrap wpbn-admin">';
         echo '<h1>' . esc_html__( 'WP Bitcoin Newsletter Settings', 'wpbn' ) . '</h1>';
         echo '<form method="post" action="options.php">';

--- a/wp-bitcoin-newsletter/src/Admin/Settings.php
+++ b/wp-bitcoin-newsletter/src/Admin/Settings.php
@@ -2,200 +2,323 @@
 
 namespace WpBitcoinNewsletter\Admin;
 
-defined('ABSPATH') || exit;
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
 
-class Settings
-{
+class Settings {
     public const OPTION_KEY = 'wpbn_settings';
 
-    public static function register(): void
-    {
-        add_action('admin_init', [__CLASS__, 'registerSettings']);
+    public static function register(): void {
+        add_action( 'admin_init', [ __CLASS__, 'registerSettings' ] );
     }
 
-    public static function getSettings(): array
-    {
+    public static function getSettings(): array {
         $defaults = [
-            'payment_provider' => 'coinsnap',
-            'default_amount' => 21,
-            'default_currency' => 'SATS',
-            'coinsnap_api_key' => '',
-            'coinsnap_store_id' => '',
-            'coinsnap_api_base' => 'https://app.coinsnap.org',
+            'payment_provider'      => 'coinsnap',
+            'default_amount'        => 21,
+            'default_currency'      => 'SATS',
+            'coinsnap_api_key'      => '',
+            'coinsnap_store_id'     => '',
+            'coinsnap_api_base'     => 'https://app.coinsnap.org',
             'coinsnap_webhook_secret' => '',
-            'btcpay_host' => '',
-            'btcpay_api_key' => '',
-            'btcpay_store_id' => '',
+            'btcpay_host'           => '',
+            'btcpay_api_key'        => '',
+            'btcpay_store_id'       => '',
             'btcpay_webhook_secret' => '',
-            'newsletter_provider' => 'wpdb',
-            'mailpoet_list_id' => '',
-            'mailchimp_api_key' => '',
+            'newsletter_provider'   => 'wpdb',
+            'mailpoet_list_id'      => '',
+            'mailchimp_api_key'     => '',
             'mailchimp_audience_id' => '',
-            'sendinblue_api_key' => '',
-            'sendinblue_list_id' => '',
+            'sendinblue_api_key'    => '',
+            'sendinblue_list_id'    => '',
             'convertkit_api_secret' => '',
-            'convertkit_form_id' => '',
+            'convertkit_form_id'    => '',
         ];
-        $defaults = apply_filters('wpbn_default_settings', $defaults);
-        $opts = get_option(self::OPTION_KEY, []);
-        if (!is_array($opts)) $opts = [];
-        return array_merge($defaults, $opts);
+        $defaults = apply_filters( 'wpbn_default_settings', $defaults );
+        $opts     = get_option( self::OPTION_KEY, [] );
+        if ( ! is_array( $opts ) ) {
+            $opts = [];
+        }
+        return array_merge( $defaults, $opts );
     }
 
-    public static function registerSettings(): void
-    {
-        register_setting('wpbn_settings_group', self::OPTION_KEY, [
-            'type' => 'array',
-            'sanitize_callback' => [__CLASS__, 'sanitize'],
-        ]);
+    public static function registerSettings(): void {
+        register_setting(
+            'wpbn_settings_group',
+            self::OPTION_KEY,
+            [
+                'type'              => 'array',
+                'sanitize_callback' => [ __CLASS__, 'sanitize' ],
+            ]
+        );
 
-        add_settings_section('wpbn_general', __('General', 'wpbn'), function () {
-            echo '<p>' . esc_html__('Configure payment and newsletter providers.', 'wpbn') . '</p>';
-        }, 'wpbn-settings');
+        add_settings_section(
+            'wpbn_general',
+            __( 'General', 'wpbn' ),
+            function () {
+                echo '<p>' . esc_html__( 'Configure payment and newsletter providers.', 'wpbn' ) . '</p>';
+            },
+            'wpbn-settings'
+        );
 
-        add_settings_field('payment_provider', __('Default Payment Provider', 'wpbn'), function () {
-            $s = self::getSettings();
-            echo '<select name="' . esc_attr(self::OPTION_KEY) . '[payment_provider]">';
-            foreach ([
-                'coinsnap' => 'Coinsnap',
-                'btcpay' => 'BTCPay',
-            ] as $k => $label) {
-                echo '<option value="' . esc_attr($k) . '" ' . selected($k, $s['payment_provider'], false) . '>' . esc_html($label) . '</option>';
-            }
-            echo '</select>';
-        }, 'wpbn-settings', 'wpbn_general');
+        add_settings_field(
+            'payment_provider',
+            __( 'Default Payment Provider', 'wpbn' ),
+            function () {
+                $s = self::getSettings();
+                echo '<select name="' . esc_attr( self::OPTION_KEY ) . '[payment_provider]">';
+                foreach ( [
+                    'coinsnap' => 'Coinsnap',
+                    'btcpay'   => 'BTCPay',
+                ] as $k => $label ) {
+                    echo '<option value="' . esc_attr( $k ) . '" ' . selected( $k, $s['payment_provider'], false ) . '>' . esc_html( $label ) . '</option>';
+                }
+                echo '</select>';
+            },
+            'wpbn-settings',
+            'wpbn_general'
+        );
 
-        add_settings_field('default_amount', __('Default Amount', 'wpbn'), function () {
-            $s = self::getSettings();
-            echo '<input type="number" min="1" name="' . esc_attr(self::OPTION_KEY) . '[default_amount]" value="' . esc_attr((string)$s['default_amount']) . '" />';
-        }, 'wpbn-settings', 'wpbn_general');
+        add_settings_field(
+            'default_amount',
+            __( 'Default Amount', 'wpbn' ),
+            function () {
+                $s = self::getSettings();
+                echo '<input type="number" min="1" name="' . esc_attr( self::OPTION_KEY ) . '[default_amount]" value="' . esc_attr( (string) $s['default_amount'] ) . '" />';
+            },
+            'wpbn-settings',
+            'wpbn_general'
+        );
 
-        add_settings_field('default_currency', __('Default Currency', 'wpbn'), function () {
-            $s = self::getSettings();
-            echo '<select name="' . esc_attr(self::OPTION_KEY) . '[default_currency]">';
-            foreach (['SATS','USD','EUR','CHF','JPY'] as $cur) {
-                echo '<option value="' . esc_attr($cur) . '" ' . selected($cur, $s['default_currency'], false) . '>' . esc_html($cur) . '</option>';
-            }
-            echo '</select>';
-        }, 'wpbn-settings', 'wpbn_general');
+        add_settings_field(
+            'default_currency',
+            __( 'Default Currency', 'wpbn' ),
+            function () {
+                $s = self::getSettings();
+                echo '<select name="' . esc_attr( self::OPTION_KEY ) . '[default_currency]">';
+                foreach ( [ 'SATS', 'USD', 'EUR', 'CHF', 'JPY' ] as $cur ) {
+                    echo '<option value="' . esc_attr( $cur ) . '" ' . selected( $cur, $s['default_currency'], false ) . '>' . esc_html( $cur ) . '</option>';
+                }
+                echo '</select>';
+            },
+            'wpbn-settings',
+            'wpbn_general'
+        );
 
-        add_settings_section('wpbn_coinsnap', __('Coinsnap', 'wpbn'), function () {}, 'wpbn-settings');
-        add_settings_field('coinsnap_api_key', __('Coinsnap API Key', 'wpbn'), function () {
-            $s = self::getSettings();
-            echo '<input type="text" class="regular-text" name="' . esc_attr(self::OPTION_KEY) . '[coinsnap_api_key]" value="' . esc_attr($s['coinsnap_api_key']) . '" />';
-        }, 'wpbn-settings', 'wpbn_coinsnap');
-        add_settings_field('coinsnap_store_id', __('Coinsnap Store ID', 'wpbn'), function () {
-            $s = self::getSettings();
-            echo '<input type="text" class="regular-text" name="' . esc_attr(self::OPTION_KEY) . '[coinsnap_store_id]" value="' . esc_attr($s['coinsnap_store_id']) . '" />';
-        }, 'wpbn-settings', 'wpbn_coinsnap');
-        add_settings_field('coinsnap_api_base', __('Coinsnap API Base', 'wpbn'), function () {
-            $s = self::getSettings();
-            echo '<input type="url" class="regular-text" placeholder="https://app.coinsnap.org" name="' . esc_attr(self::OPTION_KEY) . '[coinsnap_api_base]" value="' . esc_attr($s['coinsnap_api_base']) . '" />';
-        }, 'wpbn-settings', 'wpbn_coinsnap');
-        add_settings_field('coinsnap_webhook_secret', __('Coinsnap Webhook Secret', 'wpbn'), function () {
-            $s = self::getSettings();
-            echo '<input type="text" class="regular-text" name="' . esc_attr(self::OPTION_KEY) . '[coinsnap_webhook_secret]" value="' . esc_attr($s['coinsnap_webhook_secret']) . '" />';
-        }, 'wpbn-settings', 'wpbn_coinsnap');
+        add_settings_section( 'wpbn_coinsnap', __( 'Coinsnap', 'wpbn' ), function () {}, 'wpbn-settings' );
+        add_settings_field(
+            'coinsnap_api_key',
+            __( 'Coinsnap API Key', 'wpbn' ),
+            function () {
+                $s = self::getSettings();
+                echo '<input type="text" class="regular-text" name="' . esc_attr( self::OPTION_KEY ) . '[coinsnap_api_key]" value="' . esc_attr( $s['coinsnap_api_key'] ) . '" />';
+            },
+            'wpbn-settings',
+            'wpbn_coinsnap'
+        );
+        add_settings_field(
+            'coinsnap_store_id',
+            __( 'Coinsnap Store ID', 'wpbn' ),
+            function () {
+                $s = self::getSettings();
+                echo '<input type="text" class="regular-text" name="' . esc_attr( self::OPTION_KEY ) . '[coinsnap_store_id]" value="' . esc_attr( $s['coinsnap_store_id'] ) . '" />';
+            },
+            'wpbn-settings',
+            'wpbn_coinsnap'
+        );
+        add_settings_field(
+            'coinsnap_api_base',
+            __( 'Coinsnap API Base', 'wpbn' ),
+            function () {
+                $s = self::getSettings();
+                echo '<input type="url" class="regular-text" placeholder="https://app.coinsnap.org" name="' . esc_attr( self::OPTION_KEY ) . '[coinsnap_api_base]" value="' . esc_attr( $s['coinsnap_api_base'] ) . '" />';
+            },
+            'wpbn-settings',
+            'wpbn_coinsnap'
+        );
+        add_settings_field(
+            'coinsnap_webhook_secret',
+            __( 'Coinsnap Webhook Secret', 'wpbn' ),
+            function () {
+                $s = self::getSettings();
+                echo '<input type="text" class="regular-text" name="' . esc_attr( self::OPTION_KEY ) . '[coinsnap_webhook_secret]" value="' . esc_attr( $s['coinsnap_webhook_secret'] ) . '" />';
+            },
+            'wpbn-settings',
+            'wpbn_coinsnap'
+        );
 
-        add_settings_section('wpbn_btcpay', __('BTCPay Server', 'wpbn'), function () {}, 'wpbn-settings');
-        add_settings_field('btcpay_host', __('BTCPay Host', 'wpbn'), function () {
-            $s = self::getSettings();
-            echo '<input type="url" class="regular-text" placeholder="https://your-btcpay.example" name="' . esc_attr(self::OPTION_KEY) . '[btcpay_host]" value="' . esc_attr($s['btcpay_host']) . '" />';
-        }, 'wpbn-settings', 'wpbn_btcpay');
-        add_settings_field('btcpay_api_key', __('BTCPay API Key', 'wpbn'), function () {
-            $s = self::getSettings();
-            echo '<input type="text" class="regular-text" name="' . esc_attr(self::OPTION_KEY) . '[btcpay_api_key]" value="' . esc_attr($s['btcpay_api_key']) . '" />';
-        }, 'wpbn-settings', 'wpbn_btcpay');
-        add_settings_field('btcpay_store_id', __('BTCPay Store ID', 'wpbn'), function () {
-            $s = self::getSettings();
-            echo '<input type="text" class="regular-text" name="' . esc_attr(self::OPTION_KEY) . '[btcpay_store_id]" value="' . esc_attr($s['btcpay_store_id']) . '" />';
-        }, 'wpbn-settings', 'wpbn_btcpay');
-        add_settings_field('btcpay_webhook_secret', __('BTCPay Webhook Secret', 'wpbn'), function () {
-            $s = self::getSettings();
-            echo '<input type="text" class="regular-text" name="' . esc_attr(self::OPTION_KEY) . '[btcpay_webhook_secret]" value="' . esc_attr($s['btcpay_webhook_secret']) . '" />';
-        }, 'wpbn-settings', 'wpbn_btcpay');
+        add_settings_section( 'wpbn_btcpay', __( 'BTCPay Server', 'wpbn' ), function () {}, 'wpbn-settings' );
+        add_settings_field(
+            'btcpay_host',
+            __( 'BTCPay Host', 'wpbn' ),
+            function () {
+                $s = self::getSettings();
+                echo '<input type="url" class="regular-text" placeholder="https://your-btcpay.example" name="' . esc_attr( self::OPTION_KEY ) . '[btcpay_host]" value="' . esc_attr( $s['btcpay_host'] ) . '" />';
+            },
+            'wpbn-settings',
+            'wpbn_btcpay'
+        );
+        add_settings_field(
+            'btcpay_api_key',
+            __( 'BTCPay API Key', 'wpbn' ),
+            function () {
+                $s = self::getSettings();
+                echo '<input type="text" class="regular-text" name="' . esc_attr( self::OPTION_KEY ) . '[btcpay_api_key]" value="' . esc_attr( $s['btcpay_api_key'] ) . '" />';
+            },
+            'wpbn-settings',
+            'wpbn_btcpay'
+        );
+        add_settings_field(
+            'btcpay_store_id',
+            __( 'BTCPay Store ID', 'wpbn' ),
+            function () {
+                $s = self::getSettings();
+                echo '<input type="text" class="regular-text" name="' . esc_attr( self::OPTION_KEY ) . '[btcpay_store_id]" value="' . esc_attr( $s['btcpay_store_id'] ) . '" />';
+            },
+            'wpbn-settings',
+            'wpbn_btcpay'
+        );
+        add_settings_field(
+            'btcpay_webhook_secret',
+            __( 'BTCPay Webhook Secret', 'wpbn' ),
+            function () {
+                $s = self::getSettings();
+                echo '<input type="text" class="regular-text" name="' . esc_attr( self::OPTION_KEY ) . '[btcpay_webhook_secret]" value="' . esc_attr( $s['btcpay_webhook_secret'] ) . '" />';
+            },
+            'wpbn-settings',
+            'wpbn_btcpay'
+        );
 
-        add_settings_section('wpbn_news', __('Newsletter Provider', 'wpbn'), function () {}, 'wpbn-settings');
-        add_settings_field('newsletter_provider', __('Provider', 'wpbn'), function () {
-            $s = self::getSettings();
-            echo '<select name="' . esc_attr(self::OPTION_KEY) . '[newsletter_provider]">';
-            foreach ([
-                'wpdb' => __('WP Database (internal only)', 'wpbn'),
-                'mailpoet' => 'MailPoet',
-                'mailchimp' => 'Mailchimp',
-                'sendinblue' => 'Sendinblue/Brevo',
-                'convertkit' => 'ConvertKit',
-            ] as $k => $label) {
-                echo '<option value="' . esc_attr($k) . '" ' . selected($k, $s['newsletter_provider'], false) . '>' . esc_html($label) . '</option>';
-            }
-            echo '</select>';
-        }, 'wpbn-settings', 'wpbn_news');
+        add_settings_section( 'wpbn_news', __( 'Newsletter Provider', 'wpbn' ), function () {}, 'wpbn-settings' );
+        add_settings_field(
+            'newsletter_provider',
+            __( 'Provider', 'wpbn' ),
+            function () {
+                $s = self::getSettings();
+                echo '<select name="' . esc_attr( self::OPTION_KEY ) . '[newsletter_provider]">';
+                foreach ( [
+                    'wpdb'      => __( 'WP Database (internal only)', 'wpbn' ),
+                    'mailpoet'  => 'MailPoet',
+                    'mailchimp' => 'Mailchimp',
+                    'sendinblue'=> 'Sendinblue/Brevo',
+                    'convertkit'=> 'ConvertKit',
+                ] as $k => $label ) {
+                    echo '<option value="' . esc_attr( $k ) . '" ' . selected( $k, $s['newsletter_provider'], false ) . '>' . esc_html( $label ) . '</option>';
+                }
+                echo '</select>';
+            },
+            'wpbn-settings',
+            'wpbn_news'
+        );
 
-        add_settings_field('mailpoet_list_id', __('MailPoet List ID', 'wpbn'), function () {
-            $s = self::getSettings();
-            echo '<input type="text" class="regular-text" name="' . esc_attr(self::OPTION_KEY) . '[mailpoet_list_id]" value="' . esc_attr($s['mailpoet_list_id']) . '" />';
-        }, 'wpbn-settings', 'wpbn_news');
-        add_settings_field('mailchimp_api_key', __('Mailchimp API Key', 'wpbn'), function () {
-            $s = self::getSettings();
-            echo '<input type="text" class="regular-text" name="' . esc_attr(self::OPTION_KEY) . '[mailchimp_api_key]" value="' . esc_attr($s['mailchimp_api_key']) . '" />';
-        }, 'wpbn-settings', 'wpbn_news');
-        add_settings_field('mailchimp_audience_id', __('Mailchimp Audience ID', 'wpbn'), function () {
-            $s = self::getSettings();
-            echo '<input type="text" class="regular-text" name="' . esc_attr(self::OPTION_KEY) . '[mailchimp_audience_id]" value="' . esc_attr($s['mailchimp_audience_id']) . '" />';
-        }, 'wpbn-settings', 'wpbn_news');
+        add_settings_field(
+            'mailpoet_list_id',
+            __( 'MailPoet List ID', 'wpbn' ),
+            function () {
+                $s = self::getSettings();
+                echo '<input type="text" class="regular-text" name="' . esc_attr( self::OPTION_KEY ) . '[mailpoet_list_id]" value="' . esc_attr( $s['mailpoet_list_id'] ) . '" />';
+            },
+            'wpbn-settings',
+            'wpbn_news'
+        );
+        add_settings_field(
+            'mailchimp_api_key',
+            __( 'Mailchimp API Key', 'wpbn' ),
+            function () {
+                $s = self::getSettings();
+                echo '<input type="text" class="regular-text" name="' . esc_attr( self::OPTION_KEY ) . '[mailchimp_api_key]" value="' . esc_attr( $s['mailchimp_api_key'] ) . '" />';
+            },
+            'wpbn-settings',
+            'wpbn_news'
+        );
+        add_settings_field(
+            'mailchimp_audience_id',
+            __( 'Mailchimp Audience ID', 'wpbn' ),
+            function () {
+                $s = self::getSettings();
+                echo '<input type="text" class="regular-text" name="' . esc_attr( self::OPTION_KEY ) . '[mailchimp_audience_id]" value="' . esc_attr( $s['mailchimp_audience_id'] ) . '" />';
+            },
+            'wpbn-settings',
+            'wpbn_news'
+        );
 
-        add_settings_field('sendinblue_api_key', __('Sendinblue API Key', 'wpbn'), function () {
-            $s = self::getSettings();
-            echo '<input type="text" class="regular-text" name="' . esc_attr(self::OPTION_KEY) . '[sendinblue_api_key]" value="' . esc_attr($s['sendinblue_api_key']) . '" />';
-        }, 'wpbn-settings', 'wpbn_news');
-        add_settings_field('sendinblue_list_id', __('Sendinblue List ID', 'wpbn'), function () {
-            $s = self::getSettings();
-            echo '<input type="text" class="regular-text" name="' . esc_attr(self::OPTION_KEY) . '[sendinblue_list_id]" value="' . esc_attr($s['sendinblue_list_id']) . '" />';
-        }, 'wpbn-settings', 'wpbn_news');
+        add_settings_field(
+            'sendinblue_api_key',
+            __( 'Sendinblue API Key', 'wpbn' ),
+            function () {
+                $s = self::getSettings();
+                echo '<input type="text" class="regular-text" name="' . esc_attr( self::OPTION_KEY ) . '[sendinblue_api_key]" value="' . esc_attr( $s['sendinblue_api_key'] ) . '" />';
+            },
+            'wpbn-settings',
+            'wpbn_news'
+        );
+        add_settings_field(
+            'sendinblue_list_id',
+            __( 'Sendinblue List ID', 'wpbn' ),
+            function () {
+                $s = self::getSettings();
+                echo '<input type="text" class="regular-text" name="' . esc_attr( self::OPTION_KEY ) . '[sendinblue_list_id]" value="' . esc_attr( $s['sendinblue_list_id'] ) . '" />';
+            },
+            'wpbn-settings',
+            'wpbn_news'
+        );
 
-        add_settings_field('convertkit_api_secret', __('ConvertKit API Secret', 'wpbn'), function () {
-            $s = self::getSettings();
-            echo '<input type="text" class="regular-text" name="' . esc_attr(self::OPTION_KEY) . '[convertkit_api_secret]" value="' . esc_attr($s['convertkit_api_secret']) . '" />';
-        }, 'wpbn-settings', 'wpbn_news');
-        add_settings_field('convertkit_form_id', __('ConvertKit Form ID', 'wpbn'), function () {
-            $s = self::getSettings();
-            echo '<input type="text" class="regular-text" name="' . esc_attr(self::OPTION_KEY) . '[convertkit_form_id]" value="' . esc_attr($s['convertkit_form_id']) . '" />';
-        }, 'wpbn-settings', 'wpbn_news');
+        add_settings_field(
+            'convertkit_api_secret',
+            __( 'ConvertKit API Secret', 'wpbn' ),
+            function () {
+                $s = self::getSettings();
+                echo '<input type="text" class="regular-text" name="' . esc_attr( self::OPTION_KEY ) . '[convertkit_api_secret]" value="' . esc_attr( $s['convertkit_api_secret'] ) . '" />';
+            },
+            'wpbn-settings',
+            'wpbn_news'
+        );
+        add_settings_field(
+            'convertkit_form_id',
+            __( 'ConvertKit Form ID', 'wpbn' ),
+            function () {
+                $s = self::getSettings();
+                echo '<input type="text" class="regular-text" name="' . esc_attr( self::OPTION_KEY ) . '[convertkit_form_id]" value="' . esc_attr( $s['convertkit_form_id'] ) . '" />';
+            },
+            'wpbn-settings',
+            'wpbn_news'
+        );
     }
 
-    public static function sanitize($input)
-    {
-        if (!is_array($input)) return [];
-        $out = [];
-        $out['payment_provider'] = isset($input['payment_provider']) ? sanitize_text_field($input['payment_provider']) : 'coinsnap';
-        $out['default_amount'] = isset($input['default_amount']) ? absint($input['default_amount']) : 21;
-        $out['default_currency'] = isset($input['default_currency']) ? sanitize_text_field($input['default_currency']) : 'SATS';
-        $out['coinsnap_api_key'] = isset($input['coinsnap_api_key']) ? sanitize_text_field($input['coinsnap_api_key']) : '';
-        $out['coinsnap_store_id'] = isset($input['coinsnap_store_id']) ? sanitize_text_field($input['coinsnap_store_id']) : '';
-        $out['coinsnap_api_base'] = isset($input['coinsnap_api_base']) ? esc_url_raw($input['coinsnap_api_base']) : 'https://app.coinsnap.org';
-        $out['coinsnap_webhook_secret'] = isset($input['coinsnap_webhook_secret']) ? sanitize_text_field($input['coinsnap_webhook_secret']) : '';
-        $out['btcpay_host'] = isset($input['btcpay_host']) ? esc_url_raw($input['btcpay_host']) : '';
-        $out['btcpay_api_key'] = isset($input['btcpay_api_key']) ? sanitize_text_field($input['btcpay_api_key']) : '';
-        $out['btcpay_store_id'] = isset($input['btcpay_store_id']) ? sanitize_text_field($input['btcpay_store_id']) : '';
-        $out['btcpay_webhook_secret'] = isset($input['btcpay_webhook_secret']) ? sanitize_text_field($input['btcpay_webhook_secret']) : '';
-        $out['newsletter_provider'] = isset($input['newsletter_provider']) ? sanitize_text_field($input['newsletter_provider']) : 'wpdb';
-        $out['mailpoet_list_id'] = isset($input['mailpoet_list_id']) ? sanitize_text_field($input['mailpoet_list_id']) : '';
-        $out['mailchimp_api_key'] = isset($input['mailchimp_api_key']) ? sanitize_text_field($input['mailchimp_api_key']) : '';
-        $out['mailchimp_audience_id'] = isset($input['mailchimp_audience_id']) ? sanitize_text_field($input['mailchimp_audience_id']) : '';
-        $out['sendinblue_api_key'] = isset($input['sendinblue_api_key']) ? sanitize_text_field($input['sendinblue_api_key']) : '';
-        $out['sendinblue_list_id'] = isset($input['sendinblue_list_id']) ? sanitize_text_field($input['sendinblue_list_id']) : '';
-        $out['convertkit_api_secret'] = isset($input['convertkit_api_secret']) ? sanitize_text_field($input['convertkit_api_secret']) : '';
-        $out['convertkit_form_id'] = isset($input['convertkit_form_id']) ? sanitize_text_field($input['convertkit_form_id']) : '';
+    public static function sanitize( $input ) {
+        if ( ! is_array( $input ) ) {
+            return [];
+        }
+        $out                        = [];
+        $out['payment_provider']    = isset( $input['payment_provider'] ) ? sanitize_text_field( $input['payment_provider'] ) : 'coinsnap';
+        $out['default_amount']      = isset( $input['default_amount'] ) ? absint( $input['default_amount'] ) : 21;
+        $out['default_currency']    = isset( $input['default_currency'] ) ? sanitize_text_field( $input['default_currency'] ) : 'SATS';
+        $out['coinsnap_api_key']    = isset( $input['coinsnap_api_key'] ) ? sanitize_text_field( $input['coinsnap_api_key'] ) : '';
+        $out['coinsnap_store_id']   = isset( $input['coinsnap_store_id'] ) ? sanitize_text_field( $input['coinsnap_store_id'] ) : '';
+        $out['coinsnap_api_base']   = isset( $input['coinsnap_api_base'] ) ? esc_url_raw( $input['coinsnap_api_base'] ) : 'https://app.coinsnap.org';
+        $out['coinsnap_webhook_secret'] = isset( $input['coinsnap_webhook_secret'] ) ? sanitize_text_field( $input['coinsnap_webhook_secret'] ) : '';
+        $out['btcpay_host']         = isset( $input['btcpay_host'] ) ? esc_url_raw( $input['btcpay_host'] ) : '';
+        $out['btcpay_api_key']      = isset( $input['btcpay_api_key'] ) ? sanitize_text_field( $input['btcpay_api_key'] ) : '';
+        $out['btcpay_store_id']     = isset( $input['btcpay_store_id'] ) ? sanitize_text_field( $input['btcpay_store_id'] ) : '';
+        $out['btcpay_webhook_secret'] = isset( $input['btcpay_webhook_secret'] ) ? sanitize_text_field( $input['btcpay_webhook_secret'] ) : '';
+        $out['newsletter_provider'] = isset( $input['newsletter_provider'] ) ? sanitize_text_field( $input['newsletter_provider'] ) : 'wpdb';
+        $out['mailpoet_list_id']    = isset( $input['mailpoet_list_id'] ) ? sanitize_text_field( $input['mailpoet_list_id'] ) : '';
+        $out['mailchimp_api_key']   = isset( $input['mailchimp_api_key'] ) ? sanitize_text_field( $input['mailchimp_api_key'] ) : '';
+        $out['mailchimp_audience_id'] = isset( $input['mailchimp_audience_id'] ) ? sanitize_text_field( $input['mailchimp_audience_id'] ) : '';
+        $out['sendinblue_api_key']  = isset( $input['sendinblue_api_key'] ) ? sanitize_text_field( $input['sendinblue_api_key'] ) : '';
+        $out['sendinblue_list_id']  = isset( $input['sendinblue_list_id'] ) ? sanitize_text_field( $input['sendinblue_list_id'] ) : '';
+        $out['convertkit_api_secret'] = isset( $input['convertkit_api_secret'] ) ? sanitize_text_field( $input['convertkit_api_secret'] ) : '';
+        $out['convertkit_form_id']  = isset( $input['convertkit_form_id'] ) ? sanitize_text_field( $input['convertkit_form_id'] ) : '';
         return $out;
     }
 
-    public static function renderPage(): void
-    {
+    public static function renderPage(): void {
         echo '<div class="wrap wpbn-admin">';
-        echo '<h1>' . esc_html__('WP Bitcoin Newsletter Settings', 'wpbn') . '</h1>';
+        echo '<h1>' . esc_html__( 'WP Bitcoin Newsletter Settings', 'wpbn' ) . '</h1>';
         echo '<form method="post" action="options.php">';
-        settings_fields('wpbn_settings_group');
-        do_settings_sections('wpbn-settings');
+        settings_fields( 'wpbn_settings_group' );
+        do_settings_sections( 'wpbn-settings' );
         submit_button();
         echo '</form>';
         echo '</div>';

--- a/wp-bitcoin-newsletter/src/Admin/Settings.php
+++ b/wp-bitcoin-newsletter/src/Admin/Settings.php
@@ -20,7 +20,7 @@ class Settings {
             'default_currency'      => 'SATS',
             'coinsnap_api_key'      => '',
             'coinsnap_store_id'     => '',
-            'coinsnap_api_base'     => 'https://app.coinsnap.org',
+            'coinsnap_api_base'     => 'https://api.coinsnap.io',
             'coinsnap_webhook_secret' => '',
             'btcpay_host'           => '',
             'btcpay_api_key'        => '',
@@ -132,7 +132,7 @@ class Settings {
             __( 'Coinsnap API Base', 'wpbn' ),
             function () {
                 $s = self::get_settings();
-                echo '<input type="url" class="regular-text" placeholder="https://app.coinsnap.org" name="' . esc_attr( self::OPTION_KEY ) . '[coinsnap_api_base]" value="' . esc_attr( $s['coinsnap_api_base'] ) . '" />';
+                echo '<input type="url" class="regular-text" placeholder="https://api.coinsnap.io" name="' . esc_attr( self::OPTION_KEY ) . '[coinsnap_api_base]" value="' . esc_attr( $s['coinsnap_api_base'] ) . '" />';
             },
             'wpbn-settings',
             'wpbn_coinsnap'

--- a/wp-bitcoin-newsletter/src/Admin/Settings.php
+++ b/wp-bitcoin-newsletter/src/Admin/Settings.php
@@ -1,10 +1,11 @@
 <?php
-declare(strict_types=1);
 /**
  * Admin settings.
  *
  * @package wp-bitcoin-newsletter
  */
+
+declare(strict_types=1);
 
 namespace WpBitcoinNewsletter\Admin;
 

--- a/wp-bitcoin-newsletter/src/Admin/Settings.php
+++ b/wp-bitcoin-newsletter/src/Admin/Settings.php
@@ -6,13 +6,22 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
+/**
+ * Admin settings registration and rendering.
+ */
 class Settings {
     public const OPTION_KEY = 'wpbn_settings';
 
+    /** Register hooks to initialize settings. */
     public static function register(): void {
         add_action( 'admin_init', [ __CLASS__, 'register_settings' ] );
     }
 
+    /**
+     * Get merged settings with defaults.
+     *
+     * @return array Settings array.
+     */
     public static function get_settings(): array {
         $defaults = [
             'payment_provider'      => 'coinsnap',
@@ -43,6 +52,7 @@ class Settings {
         return array_merge( $defaults, $opts );
     }
 
+    /** Register settings, sections, and fields. */
     public static function register_settings(): void {
         register_setting(
             'wpbn_settings_group',
@@ -286,6 +296,12 @@ class Settings {
         );
     }
 
+    /**
+     * Sanitize settings array.
+     *
+     * @param mixed $input Raw input from WordPress settings API.
+     * @return array Sanitized settings.
+     */
     public static function sanitize( $input ) {
         if ( ! is_array( $input ) ) {
             return [];
@@ -313,6 +329,7 @@ class Settings {
         return $out;
     }
 
+    /** Render settings page. */
     public static function render_page(): void {
         echo '<div class="wrap wpbn-admin">';
         echo '<h1>' . esc_html__( 'WP Bitcoin Newsletter Settings', 'wpbn' ) . '</h1>';

--- a/wp-bitcoin-newsletter/src/Admin/SubscribersPage.php
+++ b/wp-bitcoin-newsletter/src/Admin/SubscribersPage.php
@@ -4,72 +4,82 @@ namespace WpBitcoinNewsletter\Admin;
 
 use WpBitcoinNewsletter\Database\Installer;
 
-defined('ABSPATH') || exit;
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
 
-class SubscribersPage
-{
-    public static function renderPage(): void
-    {
-        if (isset($_GET['wpbn_export']) && current_user_can('manage_options')) {
+class SubscribersPage {
+    public static function renderPage(): void {
+        if ( isset( $_GET['wpbn_export'] ) && current_user_can( 'manage_options' ) ) {
             self::exportCsv();
             return;
         }
 
-        $status = isset($_GET['status']) ? sanitize_text_field(wp_unslash($_GET['status'])) : '';
-        $formId = isset($_GET['form_id']) ? absint($_GET['form_id']) : 0;
+        $status = isset( $_GET['status'] ) ? sanitize_text_field( wp_unslash( $_GET['status'] ) ) : '';
+        $formId = isset( $_GET['form_id'] ) ? absint( $_GET['form_id'] ) : 0;
 
         global $wpdb;
-        $table = Installer::tableName($wpdb);
-        $where = [];
+        $table  = Installer::tableName( $wpdb );
+        $where  = [];
         $params = [];
-        if ($status) { $where[] = 'payment_status = %s'; $params[] = $status; }
-        if ($formId) { $where[] = 'form_id = %d'; $params[] = $formId; }
+        if ( $status ) {
+            $where[]  = 'payment_status = %s';
+            $params[] = $status;
+        }
+        if ( $formId ) {
+            $where[]  = 'form_id = %d';
+            $params[] = $formId;
+        }
         $sql = "SELECT id, email, first_name, last_name, payment_status, provider_sync_status, created_at, payment_amount, currency, form_id FROM {$table}";
-        if ($where) { $sql .= ' WHERE ' . implode(' AND ', $where); }
-        $sql .= ' ORDER BY id DESC LIMIT 200';
-        $items = $params ? $wpdb->get_results($wpdb->prepare($sql, $params), ARRAY_A) : $wpdb->get_results($sql, ARRAY_A);
+        if ( $where ) {
+            $sql .= ' WHERE ' . implode( ' AND ', $where );
+        }
+        $sql  .= ' ORDER BY id DESC LIMIT 200';
+        $items = $params ? $wpdb->get_results( $wpdb->prepare( $sql, $params ), ARRAY_A ) : $wpdb->get_results( $sql, ARRAY_A );
 
         echo '<div class="wrap wpbn-admin">';
-        echo '<h1>' . esc_html__('Newsletter Subscribers', 'wpbn') . '</h1>';
+        echo '<h1>' . esc_html__( 'Newsletter Subscribers', 'wpbn' ) . '</h1>';
 
         echo '<form method="get" style="margin:10px 0;">';
         echo '<input type="hidden" name="page" value="wpbn-subscribers" />';
-        echo '<label>' . esc_html__('Status', 'wpbn') . ': <select name="status">';
-        foreach (['' => __('All', 'wpbn'), 'paid' => 'paid', 'unpaid' => 'unpaid'] as $k => $label) {
-            echo '<option value="' . esc_attr($k) . '" ' . selected($k, $status, false) . '>' . esc_html($label) . '</option>';
+        echo '<label>' . esc_html__( 'Status', 'wpbn' ) . ': <select name="status">';
+        foreach ( [ '' => __( 'All', 'wpbn' ), 'paid' => 'paid', 'unpaid' => 'unpaid' ] as $k => $label ) {
+            echo '<option value="' . esc_attr( $k ) . '" ' . selected( $k, $status, false ) . '>' . esc_html( $label ) . '</option>';
         }
         echo '</select></label> ';
-        echo '<label>' . esc_html__('Form ID', 'wpbn') . ': <input type="number" name="form_id" value="' . ($formId ? (int)$formId : '') . '" /></label> ';
-        submit_button(__('Filter', 'wpbn'), 'secondary', '', false);
-        echo ' <a class="button" href="' . esc_url(add_query_arg(['wpbn_export' => 1])) . '">' . esc_html__('Export CSV', 'wpbn') . '</a>';
+        echo '<label>' . esc_html__( 'Form ID', 'wpbn' ) . ': <input type="number" name="form_id" value="' . ( $formId ? (int) $formId : '' ) . '" /></label> ';
+        submit_button( __( 'Filter', 'wpbn' ), 'secondary', '', false );
+        echo ' <a class="button" href="' . esc_url( add_query_arg( [ 'wpbn_export' => 1 ] ) ) . '">' . esc_html__( 'Export CSV', 'wpbn' ) . '</a>';
         echo '</form>';
 
         echo '<form id="wpbn-bulk" method="post" onsubmit="return false;" style="margin:10px 0;">';
-        echo '<button class="button" id="wpbn-bulk-resync">' . esc_html__('Resync Selected', 'wpbn') . '</button>';
+        echo '<button class="button" id="wpbn-bulk-resync">' . esc_html__( 'Resync Selected', 'wpbn' ) . '</button>';
         echo '</form>';
 
         echo '<table class="widefat striped" id="wpbn-table"><thead><tr>';
-        $cols = ['Select','ID','Email','Name','Form ID','Payment Status','Provider Sync','Amount','Date'];
-        foreach ($cols as $c) echo '<th>' . esc_html($c) . '</th>';
+        $cols = [ 'Select', 'ID', 'Email', 'Name', 'Form ID', 'Payment Status', 'Provider Sync', 'Amount', 'Date' ];
+        foreach ( $cols as $c ) {
+            echo '<th>' . esc_html( $c ) . '</th>';
+        }
         echo '</tr></thead><tbody>';
-        if ($items) {
-            foreach ($items as $row) {
-                $name = trim(($row['first_name'] ?? '') . ' ' . ($row['last_name'] ?? ''));
-                $amount = $row['payment_amount'] ? esc_html($row['payment_amount'] . ' ' . $row['currency']) : '';
+        if ( $items ) {
+            foreach ( $items as $row ) {
+                $name   = trim( ( $row['first_name'] ?? '' ) . ' ' . ( $row['last_name'] ?? '' ) );
+                $amount = $row['payment_amount'] ? esc_html( $row['payment_amount'] . ' ' . $row['currency'] ) : '';
                 echo '<tr>';
-                echo '<td><input type="checkbox" class="wpbn-row" value="' . (int)$row['id'] . '" /></td>';
-                echo '<td>' . esc_html((string)$row['id']) . '</td>';
-                echo '<td>' . esc_html((string)$row['email']) . '</td>';
-                echo '<td>' . esc_html($name) . '</td>';
-                echo '<td>' . esc_html((string)$row['form_id']) . '</td>';
-                echo '<td>' . esc_html((string)$row['payment_status']) . '</td>';
-                echo '<td>' . esc_html((string)$row['provider_sync_status']) . '</td>';
+                echo '<td><input type="checkbox" class="wpbn-row" value="' . (int) $row['id'] . '" /></td>';
+                echo '<td>' . esc_html( (string) $row['id'] ) . '</td>';
+                echo '<td>' . esc_html( (string) $row['email'] ) . '</td>';
+                echo '<td>' . esc_html( $name ) . '</td>';
+                echo '<td>' . esc_html( (string) $row['form_id'] ) . '</td>';
+                echo '<td>' . esc_html( (string) $row['payment_status'] ) . '</td>';
+                echo '<td>' . esc_html( (string) $row['provider_sync_status'] ) . '</td>';
                 echo '<td>' . $amount . '</td>';
-                echo '<td>' . esc_html((string)$row['created_at']) . '</td>';
+                echo '<td>' . esc_html( (string) $row['created_at'] ) . '</td>';
                 echo '</tr>';
             }
         } else {
-            echo '<tr><td colspan="9">' . esc_html__('No subscribers found.', 'wpbn') . '</td></tr>';
+            echo '<tr><td colspan="9">' . esc_html__( 'No subscribers found.', 'wpbn' ) . '</td></tr>';
         }
         echo '</tbody></table>';
 
@@ -91,25 +101,24 @@ class SubscribersPage
         echo '</div>';
     }
 
-    private static function exportCsv(): void
-    {
-        if (!current_user_can('manage_options')) {
-            wp_die(__('Unauthorized', 'wpbn'));
+    private static function exportCsv(): void {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( __( 'Unauthorized', 'wpbn' ) );
         }
         global $wpdb;
-        $table = Installer::tableName($wpdb);
-        $rows = $wpdb->get_results("SELECT * FROM {$table} ORDER BY id DESC", ARRAY_A);
+        $table = Installer::tableName( $wpdb );
+        $rows  = $wpdb->get_results( "SELECT * FROM {$table} ORDER BY id DESC", ARRAY_A );
         nocache_headers();
-        header('Content-Type: text/csv; charset=utf-8');
-        header('Content-Disposition: attachment; filename=wpbn-subscribers.csv');
-        $out = fopen('php://output', 'w');
-        if (!empty($rows)) {
-            fputcsv($out, array_keys($rows[0]));
-            foreach ($rows as $r) {
-                fputcsv($out, $r);
+        header( 'Content-Type: text/csv; charset=utf-8' );
+        header( 'Content-Disposition: attachment; filename=wpbn-subscribers.csv' );
+        $out = fopen( 'php://output', 'w' );
+        if ( ! empty( $rows ) ) {
+            fputcsv( $out, array_keys( $rows[0] ) );
+            foreach ( $rows as $r ) {
+                fputcsv( $out, $r );
             }
         }
-        fclose($out);
+        fclose( $out );
         exit;
     }
 }

--- a/wp-bitcoin-newsletter/src/Admin/SubscribersPage.php
+++ b/wp-bitcoin-newsletter/src/Admin/SubscribersPage.php
@@ -8,7 +8,11 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
+/**
+ * Admin page for viewing and exporting subscribers.
+ */
 class SubscribersPage {
+    /** Render the subscribers admin page. */
     public static function render_page(): void {
         if ( isset( $_GET['wpbn_export'] ) && current_user_can( 'manage_options' ) ) {
             self::export_csv();
@@ -101,6 +105,7 @@ class SubscribersPage {
         echo '</div>';
     }
 
+    /** Export subscribers as CSV and exit. */
     private static function export_csv(): void {
         if ( ! current_user_can( 'manage_options' ) ) {
             wp_die( __( 'Unauthorized', 'wpbn' ) );

--- a/wp-bitcoin-newsletter/src/Admin/SubscribersPage.php
+++ b/wp-bitcoin-newsletter/src/Admin/SubscribersPage.php
@@ -9,9 +9,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class SubscribersPage {
-    public static function renderPage(): void {
+    public static function render_page(): void {
         if ( isset( $_GET['wpbn_export'] ) && current_user_can( 'manage_options' ) ) {
-            self::exportCsv();
+            self::export_csv();
             return;
         }
 
@@ -101,7 +101,7 @@ class SubscribersPage {
         echo '</div>';
     }
 
-    private static function exportCsv(): void {
+    private static function export_csv(): void {
         if ( ! current_user_can( 'manage_options' ) ) {
             wp_die( __( 'Unauthorized', 'wpbn' ) );
         }

--- a/wp-bitcoin-newsletter/src/CPT/FormPostType.php
+++ b/wp-bitcoin-newsletter/src/CPT/FormPostType.php
@@ -2,279 +2,274 @@
 
 namespace WpBitcoinNewsletter\CPT;
 
-defined('ABSPATH') || exit;
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
 
-class FormPostType
-{
+class FormPostType {
     public const POST_TYPE = 'coinsnap_newsletter';
 
-    public static function register(): void
-    {
+    public static function register(): void {
         $labels = [
-            'name' => __('Newsletter Forms', 'wpbn'),
-            'singular_name' => __('Newsletter Form', 'wpbn'),
-            'add_new' => __('Add New', 'wpbn'),
-            'add_new_item' => __('Add New Newsletter Form', 'wpbn'),
-            'edit_item' => __('Edit Newsletter Form', 'wpbn'),
-            'new_item' => __('New Newsletter Form', 'wpbn'),
-            'all_items' => __('Newsletter Forms', 'wpbn'),
-            'view_item' => __('View Newsletter Form', 'wpbn'),
-            'search_items' => __('Search Newsletter Forms', 'wpbn'),
-            'not_found' => __('No forms found', 'wpbn'),
-            'not_found_in_trash' => __('No forms found in Trash', 'wpbn'),
-            'menu_name' => __('Newsletter Forms', 'wpbn'),
+            'name'               => __( 'Newsletter Forms', 'wpbn' ),
+            'singular_name'      => __( 'Newsletter Form', 'wpbn' ),
+            'add_new'            => __( 'Add New', 'wpbn' ),
+            'add_new_item'       => __( 'Add New Newsletter Form', 'wpbn' ),
+            'edit_item'          => __( 'Edit Newsletter Form', 'wpbn' ),
+            'new_item'           => __( 'New Newsletter Form', 'wpbn' ),
+            'all_items'          => __( 'Newsletter Forms', 'wpbn' ),
+            'view_item'          => __( 'View Newsletter Form', 'wpbn' ),
+            'search_items'       => __( 'Search Newsletter Forms', 'wpbn' ),
+            'not_found'          => __( 'No forms found', 'wpbn' ),
+            'not_found_in_trash' => __( 'No forms found in Trash', 'wpbn' ),
+            'menu_name'          => __( 'Newsletter Forms', 'wpbn' ),
         ];
 
-        register_post_type(self::POST_TYPE, [
-            'labels' => $labels,
-            'public' => false,
-            'show_ui' => true,
-            'show_in_menu' => 'wpbn-subscribers',
-            'menu_position' => 57,
-            'menu_icon' => 'dashicons-feedback',
-            'supports' => ['title'],
-            'has_archive' => false,
-            'show_in_rest' => false,
-        ]);
+        register_post_type(
+            self::POST_TYPE,
+            [
+                'labels'       => $labels,
+                'public'       => false,
+                'show_ui'      => true,
+                'show_in_menu' => 'wpbn-subscribers',
+                'menu_position'=> 57,
+                'menu_icon'    => 'dashicons-feedback',
+                'supports'     => [ 'title' ],
+                'has_archive'  => false,
+                'show_in_rest' => false,
+            ]
+        );
 
-        add_action('add_meta_boxes', [__CLASS__, 'registerMetaboxes']);
-        add_action('save_post_' . self::POST_TYPE, [__CLASS__, 'saveMeta'], 10, 2);
+        add_action( 'add_meta_boxes', [ __CLASS__, 'registerMetaboxes' ] );
+        add_action( 'save_post_' . self::POST_TYPE, [ __CLASS__, 'saveMeta' ], 10, 2 );
     }
 
-    public static function registerMetaboxes(): void
-    {
-        add_meta_box('wpbn_fields', __('Form Fields', 'wpbn'), [__CLASS__, 'renderFieldsMetabox'], self::POST_TYPE, 'normal');
-        add_meta_box('wpbn_payment', __('Payment Settings', 'wpbn'), [__CLASS__, 'renderPaymentMetabox'], self::POST_TYPE, 'side');
-        add_meta_box('wpbn_email', __('Email & Redirect', 'wpbn'), [__CLASS__, 'renderEmailMetabox'], self::POST_TYPE, 'normal');
-        add_meta_box('wpbn_gdpr', __('GDPR & Compliance', 'wpbn'), [__CLASS__, 'renderGdprMetabox'], self::POST_TYPE, 'normal');
-        add_meta_box('wpbn_provider', __('Newsletter Provider (Override)', 'wpbn'), [__CLASS__, 'renderProviderMetabox'], self::POST_TYPE, 'side');
-        add_meta_box('wpbn_shortcode', __('Shortcode', 'wpbn'), [__CLASS__, 'renderShortcodeMetabox'], self::POST_TYPE, 'side');
+    public static function registerMetaboxes(): void {
+        add_meta_box( 'wpbn_fields', __( 'Form Fields', 'wpbn' ), [ __CLASS__, 'renderFieldsMetabox' ], self::POST_TYPE, 'normal' );
+        add_meta_box( 'wpbn_payment', __( 'Payment Settings', 'wpbn' ), [ __CLASS__, 'renderPaymentMetabox' ], self::POST_TYPE, 'side' );
+        add_meta_box( 'wpbn_email', __( 'Email & Redirect', 'wpbn' ), [ __CLASS__, 'renderEmailMetabox' ], self::POST_TYPE, 'normal' );
+        add_meta_box( 'wpbn_gdpr', __( 'GDPR & Compliance', 'wpbn' ), [ __CLASS__, 'renderGdprMetabox' ], self::POST_TYPE, 'normal' );
+        add_meta_box( 'wpbn_provider', __( 'Newsletter Provider (Override)', 'wpbn' ), [ __CLASS__, 'renderProviderMetabox' ], self::POST_TYPE, 'side' );
+        add_meta_box( 'wpbn_shortcode', __( 'Shortcode', 'wpbn' ), [ __CLASS__, 'renderShortcodeMetabox' ], self::POST_TYPE, 'side' );
     }
 
-    public static function renderFieldsMetabox(\WP_Post $post): void
-    {
-        wp_nonce_field('wpbn_save_form_' . $post->ID, 'wpbn_form_nonce');
+    public static function renderFieldsMetabox( \WP_Post $post ): void {
+        wp_nonce_field( 'wpbn_save_form_' . $post->ID, 'wpbn_form_nonce' );
 
         $defaults = [
-            'email_label' => __('Email Address', 'wpbn'),
-            'first_name_enabled' => '1',
+            'email_label'         => __( 'Email Address', 'wpbn' ),
+            'first_name_enabled'  => '1',
             'first_name_required' => '0',
-            'first_name_label' => __('First Name', 'wpbn'),
-            'first_name_order' => '20',
-            'last_name_enabled' => '1',
-            'last_name_required' => '0',
-            'last_name_label' => __('Last Name', 'wpbn'),
-            'last_name_order' => '30',
-            'phone_enabled' => '0',
-            'phone_required' => '0',
-            'phone_label' => __('Phone Number', 'wpbn'),
-            'phone_order' => '40',
-            'company_enabled' => '0',
-            'company_required' => '0',
-            'company_label' => __('Company', 'wpbn'),
-            'company_order' => '50',
-            'custom1_enabled' => '0',
-            'custom1_required' => '0',
-            'custom1_label' => __('Custom Field 1', 'wpbn'),
-            'custom1_type' => 'text',
-            'custom1_options' => '',
-            'custom1_order' => '60',
-            'custom2_enabled' => '0',
-            'custom2_required' => '0',
-            'custom2_label' => __('Custom Field 2', 'wpbn'),
-            'custom2_type' => 'text',
-            'custom2_options' => '',
-            'custom2_order' => '70',
+            'first_name_label'    => __( 'First Name', 'wpbn' ),
+            'first_name_order'    => '20',
+            'last_name_enabled'   => '1',
+            'last_name_required'  => '0',
+            'last_name_label'     => __( 'Last Name', 'wpbn' ),
+            'last_name_order'     => '30',
+            'phone_enabled'       => '0',
+            'phone_required'      => '0',
+            'phone_label'         => __( 'Phone Number', 'wpbn' ),
+            'phone_order'         => '40',
+            'company_enabled'     => '0',
+            'company_required'    => '0',
+            'company_label'       => __( 'Company', 'wpbn' ),
+            'company_order'       => '50',
+            'custom1_enabled'     => '0',
+            'custom1_required'    => '0',
+            'custom1_label'       => __( 'Custom Field 1', 'wpbn' ),
+            'custom1_type'        => 'text',
+            'custom1_options'     => '',
+            'custom1_order'       => '60',
+            'custom2_enabled'     => '0',
+            'custom2_required'    => '0',
+            'custom2_label'       => __( 'Custom Field 2', 'wpbn' ),
+            'custom2_type'        => 'text',
+            'custom2_options'     => '',
+            'custom2_order'       => '70',
         ];
-        $values = get_post_meta($post->ID, '_wpbn_fields', true);
-        if (!is_array($values)) {
+        $values = get_post_meta( $post->ID, '_wpbn_fields', true );
+        if ( ! is_array( $values ) ) {
             $values = [];
         }
-        $values = array_merge($defaults, $values);
+        $values = array_merge( $defaults, $values );
 
-        echo '<p><label>' . esc_html__('Email Label', 'wpbn') . '</label><br />';
-        echo '<input type="text" class="widefat" name="wpbn_fields[email_label]" value="' . esc_attr($values['email_label']) . '" /></p>';
+        echo '<p><label>' . esc_html__( 'Email Label', 'wpbn' ) . '</label><br />';
+        echo '<input type="text" class="widefat" name="wpbn_fields[email_label]" value="' . esc_attr( $values['email_label'] ) . '" /></p>';
 
-        self::renderToggleRow('first_name', $values);
-        self::renderToggleRow('last_name', $values);
-        self::renderToggleRow('phone', $values);
-        self::renderToggleRow('company', $values);
-        self::renderCustomRow('custom1', $values);
-        self::renderCustomRow('custom2', $values);
+        self::renderToggleRow( 'first_name', $values );
+        self::renderToggleRow( 'last_name', $values );
+        self::renderToggleRow( 'phone', $values );
+        self::renderToggleRow( 'company', $values );
+        self::renderCustomRow( 'custom1', $values );
+        self::renderCustomRow( 'custom2', $values );
     }
 
-    private static function renderToggleRow(string $slug, array $values): void
-    {
+    private static function renderToggleRow( string $slug, array $values ): void {
         echo '<fieldset style="border:1px solid #ddd;padding:10px;margin:10px 0;">';
-        echo '<legend><strong>' . esc_html(ucwords(str_replace('_', ' ', $slug))) . '</strong></legend>';
-        echo '<label><input type="checkbox" name="wpbn_fields[' . esc_attr($slug) . '_enabled]" value="1" ' . checked('1', $values[$slug . '_enabled'], false) . ' /> ' . esc_html__('Enabled', 'wpbn') . '</label><br />';
-        echo '<label><input type="checkbox" name="wpbn_fields[' . esc_attr($slug) . '_required]" value="1" ' . checked('1', $values[$slug . '_required'], false) . ' /> ' . esc_html__('Required', 'wpbn') . '</label><br />';
-        echo '<label>' . esc_html__('Label', 'wpbn') . ': <input type="text" name="wpbn_fields[' . esc_attr($slug) . '_label]" value="' . esc_attr($values[$slug . '_label']) . '" /></label><br />';
-        echo '<label>' . esc_html__('Order', 'wpbn') . ': <input type="number" name="wpbn_fields[' . esc_attr($slug) . '_order]" value="' . esc_attr($values[$slug . '_order']) . '" /></label>';
+        echo '<legend><strong>' . esc_html( ucwords( str_replace( '_', ' ', $slug ) ) ) . '</strong></legend>';
+        echo '<label><input type="checkbox" name="wpbn_fields[' . esc_attr( $slug ) . '_enabled]" value="1" ' . checked( '1', $values[ $slug . '_enabled' ], false ) . ' /> ' . esc_html__( 'Enabled', 'wpbn' ) . '</label><br />';
+        echo '<label><input type="checkbox" name="wpbn_fields[' . esc_attr( $slug ) . '_required]" value="1" ' . checked( '1', $values[ $slug . '_required' ], false ) . ' /> ' . esc_html__( 'Required', 'wpbn' ) . '</label><br />';
+        echo '<label>' . esc_html__( 'Label', 'wpbn' ) . ': <input type="text" name="wpbn_fields[' . esc_attr( $slug ) . '_label]" value="' . esc_attr( $values[ $slug . '_label' ] ) . '" /></label><br />';
+        echo '<label>' . esc_html__( 'Order', 'wpbn' ) . ': <input type="number" name="wpbn_fields[' . esc_attr( $slug ) . '_order]" value="' . esc_attr( $values[ $slug . '_order' ] ) . '" /></label>';
         echo '</fieldset>';
     }
 
-    private static function renderCustomRow(string $slug, array $values): void
-    {
+    private static function renderCustomRow( string $slug, array $values ): void {
         echo '<fieldset style="border:1px solid #ddd;padding:10px;margin:10px 0;">';
-        echo '<legend><strong>' . esc_html(ucwords(str_replace('_', ' ', $slug))) . '</strong></legend>';
-        echo '<label><input type="checkbox" name="wpbn_fields[' . esc_attr($slug) . '_enabled]" value="1" ' . checked('1', $values[$slug . '_enabled'], false) . ' /> ' . esc_html__('Enabled', 'wpbn') . '</label><br />';
-        echo '<label><input type="checkbox" name="wpbn_fields[' . esc_attr($slug) . '_required]" value="1" ' . checked('1', $values[$slug . '_required'], false) . ' /> ' . esc_html__('Required', 'wpbn') . '</label><br />';
-        echo '<label>' . esc_html__('Label', 'wpbn') . ': <input type="text" name="wpbn_fields[' . esc_attr($slug) . '_label]" value="' . esc_attr($values[$slug . '_label']) . '" /></label><br />';
-        echo '<label>' . esc_html__('Type', 'wpbn') . ': <select name="wpbn_fields[' . esc_attr($slug) . '_type]">';
-        foreach (['text' => __('Text', 'wpbn'), 'select' => __('Select', 'wpbn')] as $k => $label) {
-            echo '<option value="' . esc_attr($k) . '" ' . selected($k, $values[$slug . '_type'], false) . '>' . esc_html($label) . '</option>';
+        echo '<legend><strong>' . esc_html( ucwords( str_replace( '_', ' ', $slug ) ) ) . '</strong></legend>';
+        echo '<label><input type="checkbox" name="wpbn_fields[' . esc_attr( $slug ) . '_enabled]" value="1" ' . checked( '1', $values[ $slug . '_enabled' ], false ) . ' /> ' . esc_html__( 'Enabled', 'wpbn' ) . '</label><br />';
+        echo '<label><input type="checkbox" name="wpbn_fields[' . esc_attr( $slug ) . '_required]" value="1" ' . checked( '1', $values[ $slug . '_required' ], false ) . ' /> ' . esc_html__( 'Required', 'wpbn' ) . '</label><br />';
+        echo '<label>' . esc_html__( 'Label', 'wpbn' ) . ': <input type="text" name="wpbn_fields[' . esc_attr( $slug ) . '_label]" value="' . esc_attr( $values[ $slug . '_label' ] ) . '" /></label><br />';
+        echo '<label>' . esc_html__( 'Type', 'wpbn' ) . ': <select name="wpbn_fields[' . esc_attr( $slug ) . '_type]">';
+        foreach ( [ 'text' => __( 'Text', 'wpbn' ), 'select' => __( 'Select', 'wpbn' ) ] as $k => $label ) {
+            echo '<option value="' . esc_attr( $k ) . '" ' . selected( $k, $values[ $slug . '_type' ], false ) . '>' . esc_html( $label ) . '</option>';
         }
         echo '</select></label><br />';
-        echo '<label>' . esc_html__('Options (comma-separated, for select)', 'wpbn') . ': <input type="text" class="widefat" name="wpbn_fields[' . esc_attr($slug) . '_options]" value="' . esc_attr($values[$slug . '_options']) . '" /></label><br />';
-        echo '<label>' . esc_html__('Order', 'wpbn') . ': <input type="number" name="wpbn_fields[' . esc_attr($slug) . '_order]" value="' . esc_attr($values[$slug . '_order']) . '" /></label>';
+        echo '<label>' . esc_html__( 'Options (comma-separated, for select)', 'wpbn' ) . ': <input type="text" class="widefat" name="wpbn_fields[' . esc_attr( $slug ) . '_options]" value="' . esc_attr( $values[ $slug . '_options' ] ) . '" /></label><br />';
+        echo '<label>' . esc_html__( 'Order', 'wpbn' ) . ': <input type="number" name="wpbn_fields[' . esc_attr( $slug ) . '_order]" value="' . esc_attr( $values[ $slug . '_order' ] ) . '" /></label>';
         echo '</fieldset>';
     }
 
-    public static function renderPaymentMetabox(\WP_Post $post): void
-    {
+    public static function renderPaymentMetabox( \WP_Post $post ): void {
         $defaults = [
-            'amount' => '21',
-            'currency' => 'SATS',
+            'amount'            => '21',
+            'currency'          => 'SATS',
             'provider_override' => '',
         ];
-        $values = get_post_meta($post->ID, '_wpbn_payment', true);
-        if (!is_array($values)) {
+        $values = get_post_meta( $post->ID, '_wpbn_payment', true );
+        if ( ! is_array( $values ) ) {
             $values = [];
         }
-        $values = array_merge($defaults, $values);
+        $values = array_merge( $defaults, $values );
 
-        echo '<p><label>' . esc_html__('Amount', 'wpbn') . ': <input type="number" min="1" name="wpbn_payment[amount]" value="' . esc_attr($values['amount']) . '" /></label></p>';
-        echo '<p><label>' . esc_html__('Currency', 'wpbn') . ': <select name="wpbn_payment[currency]">';
-        foreach (['SATS', 'USD', 'EUR', 'CHF', 'JPY'] as $cur) {
-            echo '<option value="' . esc_attr($cur) . '" ' . selected($cur, $values['currency'], false) . '>' . esc_html($cur) . '</option>';
+        echo '<p><label>' . esc_html__( 'Amount', 'wpbn' ) . ': <input type="number" min="1" name="wpbn_payment[amount]" value="' . esc_attr( $values['amount'] ) . '" /></label></p>';
+        echo '<p><label>' . esc_html__( 'Currency', 'wpbn' ) . ': <select name="wpbn_payment[currency]">';
+        foreach ( [ 'SATS', 'USD', 'EUR', 'CHF', 'JPY' ] as $cur ) {
+            echo '<option value="' . esc_attr( $cur ) . '" ' . selected( $cur, $values['currency'], false ) . '>' . esc_html( $cur ) . '</option>';
         }
         echo '</select></label></p>';
 
-        echo '<p><label>' . esc_html__('Override Payment Provider (global default otherwise)', 'wpbn') . ': <select name="wpbn_payment[provider_override]">';
-        foreach (['' => __('Use Global Default', 'wpbn'), 'coinsnap' => 'Coinsnap', 'btcpay' => 'BTCPay'] as $k => $label) {
-            echo '<option value="' . esc_attr($k) . '" ' . selected($k, $values['provider_override'], false) . '>' . esc_html($label) . '</option>';
+        echo '<p><label>' . esc_html__( 'Override Payment Provider (global default otherwise)', 'wpbn' ) . ': <select name="wpbn_payment[provider_override]">';
+        foreach ( [ '' => __( 'Use Global Default', 'wpbn' ), 'coinsnap' => 'Coinsnap', 'btcpay' => 'BTCPay' ] as $k => $label ) {
+            echo '<option value="' . esc_attr( $k ) . '" ' . selected( $k, $values['provider_override'], false ) . '>' . esc_html( $label ) . '</option>';
         }
         echo '</select></label></p>';
     }
 
-    public static function renderEmailMetabox(\WP_Post $post): void
-    {
+    public static function renderEmailMetabox( \WP_Post $post ): void {
         $defaults = [
-            'welcome_url' => '',
-            'email_template' => '',
-            'double_opt_in' => '0',
+            'welcome_url'      => '',
+            'email_template'   => '',
+            'double_opt_in'    => '0',
             'unsubscribe_page' => '',
         ];
-        $values = get_post_meta($post->ID, '_wpbn_email', true);
-        if (!is_array($values)) {
+        $values = get_post_meta( $post->ID, '_wpbn_email', true );
+        if ( ! is_array( $values ) ) {
             $values = [];
         }
-        $values = array_merge($defaults, $values);
+        $values = array_merge( $defaults, $values );
 
-        echo '<p><label>' . esc_html__('Welcome Page URL', 'wpbn') . '<br /><input type="url" class="widefat" name="wpbn_email[welcome_url]" value="' . esc_attr($values['welcome_url']) . '" /></label></p>';
-        echo '<p><label><input type="checkbox" name="wpbn_email[double_opt_in]" value="1" ' . checked('1', $values['double_opt_in'], false) . ' /> ' . esc_html__('Enable Double Opt-in (if provider supports)', 'wpbn') . '</label></p>';
-        echo '<p><label>' . esc_html__('Unsubscribe Page URL', 'wpbn') . '<br /><input type="url" class="widefat" name="wpbn_email[unsubscribe_page]" value="' . esc_attr($values['unsubscribe_page']) . '" /></label></p>';
-        echo '<p><label>' . esc_html__('Confirmation Email Template (HTML allowed)', 'wpbn') . '<br />';
-        echo '<textarea class="widefat" rows="6" name="wpbn_email[email_template]">' . esc_textarea($values['email_template']) . '</textarea></label></p>';
+        echo '<p><label>' . esc_html__( 'Welcome Page URL', 'wpbn' ) . '<br /><input type="url" class="widefat" name="wpbn_email[welcome_url]" value="' . esc_attr( $values['welcome_url'] ) . '" /></label></p>';
+        echo '<p><label><input type="checkbox" name="wpbn_email[double_opt_in]" value="1" ' . checked( '1', $values['double_opt_in'], false ) . ' /> ' . esc_html__( 'Enable Double Opt-in (if provider supports)', 'wpbn' ) . '</label></p>';
+        echo '<p><label>' . esc_html__( 'Unsubscribe Page URL', 'wpbn' ) . '<br /><input type="url" class="widefat" name="wpbn_email[unsubscribe_page]" value="' . esc_attr( $values['unsubscribe_page'] ) . '" /></label></p>';
+        echo '<p><label>' . esc_html__( 'Confirmation Email Template (HTML allowed)', 'wpbn' ) . '<br />';
+        echo '<textarea class="widefat" rows="6" name="wpbn_email[email_template]">' . esc_textarea( $values['email_template'] ) . '</textarea></label></p>';
     }
 
-    public static function renderGdprMetabox(\WP_Post $post): void
-    {
+    public static function renderGdprMetabox( \WP_Post $post ): void {
         $defaults = [
-            'gdpr_text' => __('I consent to receive newsletters and accept the privacy policy.', 'wpbn'),
-            'retention_days' => '0',
+            'gdpr_text'          => __( 'I consent to receive newsletters and accept the privacy policy.', 'wpbn' ),
+            'retention_days'     => '0',
             'privacy_policy_url' => '',
         ];
-        $values = get_post_meta($post->ID, '_wpbn_gdpr', true);
-        if (!is_array($values)) {
+        $values = get_post_meta( $post->ID, '_wpbn_gdpr', true );
+        if ( ! is_array( $values ) ) {
             $values = [];
         }
-        $values = array_merge($defaults, $values);
+        $values = array_merge( $defaults, $values );
 
-        echo '<p><label>' . esc_html__('GDPR Consent Text', 'wpbn') . '<br />';
-        echo '<textarea class="widefat" rows="4" name="wpbn_gdpr[gdpr_text]">' . esc_textarea($values['gdpr_text']) . '</textarea></label></p>';
-        echo '<p><label>' . esc_html__('Privacy Policy URL', 'wpbn') . '<br /><input type="url" class="widefat" name="wpbn_gdpr[privacy_policy_url]" value="' . esc_attr($values['privacy_policy_url']) . '" /></label></p>';
-        echo '<p><label>' . esc_html__('Data Retention (days, 0 = keep indefinitely)', 'wpbn') . ': <input type="number" min="0" name="wpbn_gdpr[retention_days]" value="' . esc_attr($values['retention_days']) . '" /></label></p>';
+        echo '<p><label>' . esc_html__( 'GDPR Consent Text', 'wpbn' ) . '<br />';
+        echo '<textarea class="widefat" rows="4" name="wpbn_gdpr[gdpr_text]">' . esc_textarea( $values['gdpr_text'] ) . '</textarea></label></p>';
+        echo '<p><label>' . esc_html__( 'Privacy Policy URL', 'wpbn' ) . '<br /><input type="url" class="widefat" name="wpbn_gdpr[privacy_policy_url]" value="' . esc_attr( $values['privacy_policy_url'] ) . '" /></label></p>';
+        echo '<p><label>' . esc_html__( 'Data Retention (days, 0 = keep indefinitely)', 'wpbn' ) . ': <input type="number" min="0" name="wpbn_gdpr[retention_days]" value="' . esc_attr( $values['retention_days'] ) . '" /></label></p>';
     }
 
-    public static function renderProviderMetabox(\WP_Post $post): void
-    {
+    public static function renderProviderMetabox( \WP_Post $post ): void {
         $defaults = [
-            'provider_override' => '',
-            'mailpoet_list_id' => '',
+            'provider_override'     => '',
+            'mailpoet_list_id'      => '',
             'mailchimp_audience_id' => '',
-            'sendinblue_list_id' => '',
-            'convertkit_form_id' => '',
+            'sendinblue_list_id'    => '',
+            'convertkit_form_id'    => '',
         ];
-        $values = get_post_meta($post->ID, '_wpbn_provider', true);
-        if (!is_array($values)) $values = [];
-        $values = array_merge($defaults, $values);
+        $values = get_post_meta( $post->ID, '_wpbn_provider', true );
+        if ( ! is_array( $values ) ) {
+            $values = [];
+        }
+        $values = array_merge( $defaults, $values );
 
-        echo '<p><label>' . esc_html__('Override Newsletter Provider (global default otherwise)', 'wpbn') . ': <select name="wpbn_provider[provider_override]">';
-        foreach ([
-            '' => __('Use Global Default', 'wpbn'),
-            'wpdb' => __('WP Database (internal only)', 'wpbn'),
+        echo '<p><label>' . esc_html__( 'Override Newsletter Provider (global default otherwise)', 'wpbn' ) . ': <select name="wpbn_provider[provider_override]">';
+        foreach ( [
+            ''         => __( 'Use Global Default', 'wpbn' ),
+            'wpdb'     => __( 'WP Database (internal only)', 'wpbn' ),
             'mailpoet' => 'MailPoet',
-            'mailchimp' => 'Mailchimp',
+            'mailchimp'=> 'Mailchimp',
             'sendinblue' => 'Sendinblue/Brevo',
             'convertkit' => 'ConvertKit',
-        ] as $k => $label) {
-            echo '<option value="' . esc_attr($k) . '" ' . selected($k, $values['provider_override'], false) . '>' . esc_html($label) . '</option>';
+        ] as $k => $label ) {
+            echo '<option value="' . esc_attr( $k ) . '" ' . selected( $k, $values['provider_override'], false ) . '>' . esc_html( $label ) . '</option>';
         }
         echo '</select></label></p>';
 
-        echo '<p><label>' . esc_html__('MailPoet List ID (override)', 'wpbn') . '<br /><input type="text" class="widefat" name="wpbn_provider[mailpoet_list_id]" value="' . esc_attr($values['mailpoet_list_id']) . '" /></label></p>';
-        echo '<p><label>' . esc_html__('Mailchimp Audience ID (override)', 'wpbn') . '<br /><input type="text" class="widefat" name="wpbn_provider[mailchimp_audience_id]" value="' . esc_attr($values['mailchimp_audience_id']) . '" /></label></p>';
-        echo '<p><label>' . esc_html__('Sendinblue List ID (override)', 'wpbn') . '<br /><input type="text" class="widefat" name="wpbn_provider[sendinblue_list_id]" value="' . esc_attr($values['sendinblue_list_id']) . '" /></label></p>';
-        echo '<p><label>' . esc_html__('ConvertKit Form ID (override)', 'wpbn') . '<br /><input type="text" class="widefat" name="wpbn_provider[convertkit_form_id]" value="' . esc_attr($values['convertkit_form_id']) . '" /></label></p>';
+        echo '<p><label>' . esc_html__( 'MailPoet List ID (override)', 'wpbn' ) . '<br /><input type="text" class="widefat" name="wpbn_provider[mailpoet_list_id]" value="' . esc_attr( $values['mailpoet_list_id'] ) . '" /></label></p>';
+        echo '<p><label>' . esc_html__( 'Mailchimp Audience ID (override)', 'wpbn' ) . '<br /><input type="text" class="widefat" name="wpbn_provider[mailchimp_audience_id]" value="' . esc_attr( $values['mailchimp_audience_id'] ) . '" /></label></p>';
+        echo '<p><label>' . esc_html__( 'Sendinblue List ID (override)', 'wpbn' ) . '<br /><input type="text" class="widefat" name="wpbn_provider[sendinblue_list_id]" value="' . esc_attr( $values['sendinblue_list_id'] ) . '" /></label></p>';
+        echo '<p><label>' . esc_html__( 'ConvertKit Form ID (override)', 'wpbn' ) . '<br /><input type="text" class="widefat" name="wpbn_provider[convertkit_form_id]" value="' . esc_attr( $values['convertkit_form_id'] ) . '" /></label></p>';
     }
 
-    public static function renderShortcodeMetabox(\WP_Post $post): void
-    {
-        $shortcode = '[coinsnap_newsletter_form id="' . (int)$post->ID . '"]';
-        echo '<input type="text" class="widefat" readonly value="' . esc_attr($shortcode) . '" onclick="this.select();" />';
+    public static function renderShortcodeMetabox( \WP_Post $post ): void {
+        $shortcode = '[coinsnap_newsletter_form id="' . (int) $post->ID . '"]';
+        echo '<input type="text" class="widefat" readonly value="' . esc_attr( $shortcode ) . '" onclick="this.select();" />';
     }
 
-    public static function saveMeta(int $postId, \WP_Post $post): void
-    {
-        if (!isset($_POST['wpbn_form_nonce']) || !wp_verify_nonce(sanitize_text_field($_POST['wpbn_form_nonce']), 'wpbn_save_form_' . $postId)) {
+    public static function saveMeta( int $postId, \WP_Post $post ): void {
+        if ( ! isset( $_POST['wpbn_form_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['wpbn_form_nonce'] ) ), 'wpbn_save_form_' . $postId ) ) {
             return;
         }
-        if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
+        if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
             return;
         }
-        if (!current_user_can('edit_post', $postId)) {
+        if ( ! current_user_can( 'edit_post', $postId ) ) {
             return;
         }
 
-        $fields = isset($_POST['wpbn_fields']) && is_array($_POST['wpbn_fields']) ? array_map('sanitize_text_field', wp_unslash($_POST['wpbn_fields'])) : [];
-        $payment = isset($_POST['wpbn_payment']) && is_array($_POST['wpbn_payment']) ? array_map('sanitize_text_field', wp_unslash($_POST['wpbn_payment'])) : [];
-        $email = isset($_POST['wpbn_email']) && is_array($_POST['wpbn_email']) ? wp_unslash($_POST['wpbn_email']) : [];
-        $gdpr = isset($_POST['wpbn_gdpr']) && is_array($_POST['wpbn_gdpr']) ? wp_unslash($_POST['wpbn_gdpr']) : [];
-        $provider = isset($_POST['wpbn_provider']) && is_array($_POST['wpbn_provider']) ? wp_unslash($_POST['wpbn_provider']) : [];
+        $fields   = isset( $_POST['wpbn_fields'] ) && is_array( $_POST['wpbn_fields'] ) ? array_map( 'sanitize_text_field', wp_unslash( $_POST['wpbn_fields'] ) ) : [];
+        $payment  = isset( $_POST['wpbn_payment'] ) && is_array( $_POST['wpbn_payment'] ) ? array_map( 'sanitize_text_field', wp_unslash( $_POST['wpbn_payment'] ) ) : [];
+        $email    = isset( $_POST['wpbn_email'] ) && is_array( $_POST['wpbn_email'] ) ? wp_unslash( $_POST['wpbn_email'] ) : [];
+        $gdpr     = isset( $_POST['wpbn_gdpr'] ) && is_array( $_POST['wpbn_gdpr'] ) ? wp_unslash( $_POST['wpbn_gdpr'] ) : [];
+        $provider = isset( $_POST['wpbn_provider'] ) && is_array( $_POST['wpbn_provider'] ) ? wp_unslash( $_POST['wpbn_provider'] ) : [];
 
-        // Sanitize more complex fields
-        $email['email_template'] = isset($email['email_template']) ? wp_kses_post($email['email_template']) : '';
-        $email['welcome_url'] = isset($email['welcome_url']) ? esc_url_raw($email['welcome_url']) : '';
-        $email['unsubscribe_page'] = isset($email['unsubscribe_page']) ? esc_url_raw($email['unsubscribe_page']) : '';
-        $email['double_opt_in'] = isset($email['double_opt_in']) && $email['double_opt_in'] ? '1' : '0';
+        // Sanitize more complex fields.
+        $email['email_template']   = isset( $email['email_template'] ) ? wp_kses_post( $email['email_template'] ) : '';
+        $email['welcome_url']      = isset( $email['welcome_url'] ) ? esc_url_raw( $email['welcome_url'] ) : '';
+        $email['unsubscribe_page'] = isset( $email['unsubscribe_page'] ) ? esc_url_raw( $email['unsubscribe_page'] ) : '';
+        $email['double_opt_in']    = isset( $email['double_opt_in'] ) && $email['double_opt_in'] ? '1' : '0';
 
-        $gdpr['gdpr_text'] = isset($gdpr['gdpr_text']) ? wp_kses_post($gdpr['gdpr_text']) : '';
-        $gdpr['privacy_policy_url'] = isset($gdpr['privacy_policy_url']) ? esc_url_raw($gdpr['privacy_policy_url']) : '';
-        $gdpr['retention_days'] = isset($gdpr['retention_days']) ? absint($gdpr['retention_days']) : 0;
+        $gdpr['gdpr_text']          = isset( $gdpr['gdpr_text'] ) ? wp_kses_post( $gdpr['gdpr_text'] ) : '';
+        $gdpr['privacy_policy_url'] = isset( $gdpr['privacy_policy_url'] ) ? esc_url_raw( $gdpr['privacy_policy_url'] ) : '';
+        $gdpr['retention_days']     = isset( $gdpr['retention_days'] ) ? absint( $gdpr['retention_days'] ) : 0;
 
-        $provider['provider_override'] = isset($provider['provider_override']) ? sanitize_text_field($provider['provider_override']) : '';
-        $provider['mailpoet_list_id'] = isset($provider['mailpoet_list_id']) ? sanitize_text_field($provider['mailpoet_list_id']) : '';
-        $provider['mailchimp_audience_id'] = isset($provider['mailchimp_audience_id']) ? sanitize_text_field($provider['mailchimp_audience_id']) : '';
-        $provider['sendinblue_list_id'] = isset($provider['sendinblue_list_id']) ? sanitize_text_field($provider['sendinblue_list_id']) : '';
-        $provider['convertkit_form_id'] = isset($provider['convertkit_form_id']) ? sanitize_text_field($provider['convertkit_form_id']) : '';
+        $provider['provider_override']     = isset( $provider['provider_override'] ) ? sanitize_text_field( $provider['provider_override'] ) : '';
+        $provider['mailpoet_list_id']      = isset( $provider['mailpoet_list_id'] ) ? sanitize_text_field( $provider['mailpoet_list_id'] ) : '';
+        $provider['mailchimp_audience_id'] = isset( $provider['mailchimp_audience_id'] ) ? sanitize_text_field( $provider['mailchimp_audience_id'] ) : '';
+        $provider['sendinblue_list_id']    = isset( $provider['sendinblue_list_id'] ) ? sanitize_text_field( $provider['sendinblue_list_id'] ) : '';
+        $provider['convertkit_form_id']    = isset( $provider['convertkit_form_id'] ) ? sanitize_text_field( $provider['convertkit_form_id'] ) : '';
 
-        update_post_meta($postId, '_wpbn_fields', $fields);
-        update_post_meta($postId, '_wpbn_payment', $payment);
-        update_post_meta($postId, '_wpbn_email', $email);
-        update_post_meta($postId, '_wpbn_gdpr', $gdpr);
-        update_post_meta($postId, '_wpbn_provider', $provider);
+        update_post_meta( $postId, '_wpbn_fields', $fields );
+        update_post_meta( $postId, '_wpbn_payment', $payment );
+        update_post_meta( $postId, '_wpbn_email', $email );
+        update_post_meta( $postId, '_wpbn_gdpr', $gdpr );
+        update_post_meta( $postId, '_wpbn_provider', $provider );
     }
 }
 

--- a/wp-bitcoin-newsletter/src/CPT/FormPostType.php
+++ b/wp-bitcoin-newsletter/src/CPT/FormPostType.php
@@ -40,20 +40,20 @@ class FormPostType {
             ]
         );
 
-        add_action( 'add_meta_boxes', [ __CLASS__, 'registerMetaboxes' ] );
-        add_action( 'save_post_' . self::POST_TYPE, [ __CLASS__, 'saveMeta' ], 10, 2 );
+        add_action( 'add_meta_boxes', [ __CLASS__, 'register_metaboxes' ] );
+        add_action( 'save_post_' . self::POST_TYPE, [ __CLASS__, 'save_meta' ], 10, 2 );
     }
 
-    public static function registerMetaboxes(): void {
-        add_meta_box( 'wpbn_fields', __( 'Form Fields', 'wpbn' ), [ __CLASS__, 'renderFieldsMetabox' ], self::POST_TYPE, 'normal' );
-        add_meta_box( 'wpbn_payment', __( 'Payment Settings', 'wpbn' ), [ __CLASS__, 'renderPaymentMetabox' ], self::POST_TYPE, 'side' );
-        add_meta_box( 'wpbn_email', __( 'Email & Redirect', 'wpbn' ), [ __CLASS__, 'renderEmailMetabox' ], self::POST_TYPE, 'normal' );
-        add_meta_box( 'wpbn_gdpr', __( 'GDPR & Compliance', 'wpbn' ), [ __CLASS__, 'renderGdprMetabox' ], self::POST_TYPE, 'normal' );
-        add_meta_box( 'wpbn_provider', __( 'Newsletter Provider (Override)', 'wpbn' ), [ __CLASS__, 'renderProviderMetabox' ], self::POST_TYPE, 'side' );
-        add_meta_box( 'wpbn_shortcode', __( 'Shortcode', 'wpbn' ), [ __CLASS__, 'renderShortcodeMetabox' ], self::POST_TYPE, 'side' );
+    public static function register_metaboxes(): void {
+        add_meta_box( 'wpbn_fields', __( 'Form Fields', 'wpbn' ), [ __CLASS__, 'render_fields_metabox' ], self::POST_TYPE, 'normal' );
+        add_meta_box( 'wpbn_payment', __( 'Payment Settings', 'wpbn' ), [ __CLASS__, 'render_payment_metabox' ], self::POST_TYPE, 'side' );
+        add_meta_box( 'wpbn_email', __( 'Email & Redirect', 'wpbn' ), [ __CLASS__, 'render_email_metabox' ], self::POST_TYPE, 'normal' );
+        add_meta_box( 'wpbn_gdpr', __( 'GDPR & Compliance', 'wpbn' ), [ __CLASS__, 'render_gdpr_metabox' ], self::POST_TYPE, 'normal' );
+        add_meta_box( 'wpbn_provider', __( 'Newsletter Provider (Override)', 'wpbn' ), [ __CLASS__, 'render_provider_metabox' ], self::POST_TYPE, 'side' );
+        add_meta_box( 'wpbn_shortcode', __( 'Shortcode', 'wpbn' ), [ __CLASS__, 'render_shortcode_metabox' ], self::POST_TYPE, 'side' );
     }
 
-    public static function renderFieldsMetabox( \WP_Post $post ): void {
+    public static function render_fields_metabox( \WP_Post $post ): void {
         wp_nonce_field( 'wpbn_save_form_' . $post->ID, 'wpbn_form_nonce' );
 
         $defaults = [
@@ -96,15 +96,15 @@ class FormPostType {
         echo '<p><label>' . esc_html__( 'Email Label', 'wpbn' ) . '</label><br />';
         echo '<input type="text" class="widefat" name="wpbn_fields[email_label]" value="' . esc_attr( $values['email_label'] ) . '" /></p>';
 
-        self::renderToggleRow( 'first_name', $values );
-        self::renderToggleRow( 'last_name', $values );
-        self::renderToggleRow( 'phone', $values );
-        self::renderToggleRow( 'company', $values );
-        self::renderCustomRow( 'custom1', $values );
-        self::renderCustomRow( 'custom2', $values );
+        self::render_toggle_row( 'first_name', $values );
+        self::render_toggle_row( 'last_name', $values );
+        self::render_toggle_row( 'phone', $values );
+        self::render_toggle_row( 'company', $values );
+        self::render_custom_row( 'custom1', $values );
+        self::render_custom_row( 'custom2', $values );
     }
 
-    private static function renderToggleRow( string $slug, array $values ): void {
+    private static function render_toggle_row( string $slug, array $values ): void {
         echo '<fieldset style="border:1px solid #ddd;padding:10px;margin:10px 0;">';
         echo '<legend><strong>' . esc_html( ucwords( str_replace( '_', ' ', $slug ) ) ) . '</strong></legend>';
         echo '<label><input type="checkbox" name="wpbn_fields[' . esc_attr( $slug ) . '_enabled]" value="1" ' . checked( '1', $values[ $slug . '_enabled' ], false ) . ' /> ' . esc_html__( 'Enabled', 'wpbn' ) . '</label><br />';
@@ -114,7 +114,7 @@ class FormPostType {
         echo '</fieldset>';
     }
 
-    private static function renderCustomRow( string $slug, array $values ): void {
+    private static function render_custom_row( string $slug, array $values ): void {
         echo '<fieldset style="border:1px solid #ddd;padding:10px;margin:10px 0;">';
         echo '<legend><strong>' . esc_html( ucwords( str_replace( '_', ' ', $slug ) ) ) . '</strong></legend>';
         echo '<label><input type="checkbox" name="wpbn_fields[' . esc_attr( $slug ) . '_enabled]" value="1" ' . checked( '1', $values[ $slug . '_enabled' ], false ) . ' /> ' . esc_html__( 'Enabled', 'wpbn' ) . '</label><br />';
@@ -130,7 +130,7 @@ class FormPostType {
         echo '</fieldset>';
     }
 
-    public static function renderPaymentMetabox( \WP_Post $post ): void {
+    public static function render_payment_metabox( \WP_Post $post ): void {
         $defaults = [
             'amount'            => '21',
             'currency'          => 'SATS',
@@ -156,7 +156,7 @@ class FormPostType {
         echo '</select></label></p>';
     }
 
-    public static function renderEmailMetabox( \WP_Post $post ): void {
+    public static function render_email_metabox( \WP_Post $post ): void {
         $defaults = [
             'welcome_url'      => '',
             'email_template'   => '',
@@ -176,7 +176,7 @@ class FormPostType {
         echo '<textarea class="widefat" rows="6" name="wpbn_email[email_template]">' . esc_textarea( $values['email_template'] ) . '</textarea></label></p>';
     }
 
-    public static function renderGdprMetabox( \WP_Post $post ): void {
+    public static function render_gdpr_metabox( \WP_Post $post ): void {
         $defaults = [
             'gdpr_text'          => __( 'I consent to receive newsletters and accept the privacy policy.', 'wpbn' ),
             'retention_days'     => '0',
@@ -194,7 +194,7 @@ class FormPostType {
         echo '<p><label>' . esc_html__( 'Data Retention (days, 0 = keep indefinitely)', 'wpbn' ) . ': <input type="number" min="0" name="wpbn_gdpr[retention_days]" value="' . esc_attr( $values['retention_days'] ) . '" /></label></p>';
     }
 
-    public static function renderProviderMetabox( \WP_Post $post ): void {
+    public static function render_provider_metabox( \WP_Post $post ): void {
         $defaults = [
             'provider_override'     => '',
             'mailpoet_list_id'      => '',
@@ -227,12 +227,12 @@ class FormPostType {
         echo '<p><label>' . esc_html__( 'ConvertKit Form ID (override)', 'wpbn' ) . '<br /><input type="text" class="widefat" name="wpbn_provider[convertkit_form_id]" value="' . esc_attr( $values['convertkit_form_id'] ) . '" /></label></p>';
     }
 
-    public static function renderShortcodeMetabox( \WP_Post $post ): void {
+    public static function render_shortcode_metabox( \WP_Post $post ): void {
         $shortcode = '[coinsnap_newsletter_form id="' . (int) $post->ID . '"]';
         echo '<input type="text" class="widefat" readonly value="' . esc_attr( $shortcode ) . '" onclick="this.select();" />';
     }
 
-    public static function saveMeta( int $postId, \WP_Post $post ): void {
+    public static function save_meta( int $postId, \WP_Post $post ): void {
         if ( ! isset( $_POST['wpbn_form_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['wpbn_form_nonce'] ) ), 'wpbn_save_form_' . $postId ) ) {
             return;
         }

--- a/wp-bitcoin-newsletter/src/CPT/FormPostType.php
+++ b/wp-bitcoin-newsletter/src/CPT/FormPostType.php
@@ -6,9 +6,13 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
+/**
+ * Custom Post Type for newsletter forms and its meta UI.
+ */
 class FormPostType {
     public const POST_TYPE = 'coinsnap_newsletter';
 
+    /** Register CPT and metabox hooks. */
     public static function register(): void {
         $labels = [
             'name'               => __( 'Newsletter Forms', 'wpbn' ),
@@ -44,6 +48,7 @@ class FormPostType {
         add_action( 'save_post_' . self::POST_TYPE, [ __CLASS__, 'save_meta' ], 10, 2 );
     }
 
+    /** Register meta boxes for the CPT. */
     public static function register_metaboxes(): void {
         add_meta_box( 'wpbn_fields', __( 'Form Fields', 'wpbn' ), [ __CLASS__, 'render_fields_metabox' ], self::POST_TYPE, 'normal' );
         add_meta_box( 'wpbn_payment', __( 'Payment Settings', 'wpbn' ), [ __CLASS__, 'render_payment_metabox' ], self::POST_TYPE, 'side' );
@@ -53,6 +58,7 @@ class FormPostType {
         add_meta_box( 'wpbn_shortcode', __( 'Shortcode', 'wpbn' ), [ __CLASS__, 'render_shortcode_metabox' ], self::POST_TYPE, 'side' );
     }
 
+    /** Render the fields metabox. */
     public static function render_fields_metabox( \WP_Post $post ): void {
         wp_nonce_field( 'wpbn_save_form_' . $post->ID, 'wpbn_form_nonce' );
 
@@ -104,6 +110,7 @@ class FormPostType {
         self::render_custom_row( 'custom2', $values );
     }
 
+    /** Render one toggle-able field row. */
     private static function render_toggle_row( string $slug, array $values ): void {
         echo '<fieldset style="border:1px solid #ddd;padding:10px;margin:10px 0;">';
         echo '<legend><strong>' . esc_html( ucwords( str_replace( '_', ' ', $slug ) ) ) . '</strong></legend>';
@@ -114,6 +121,7 @@ class FormPostType {
         echo '</fieldset>';
     }
 
+    /** Render one custom-field configuration row. */
     private static function render_custom_row( string $slug, array $values ): void {
         echo '<fieldset style="border:1px solid #ddd;padding:10px;margin:10px 0;">';
         echo '<legend><strong>' . esc_html( ucwords( str_replace( '_', ' ', $slug ) ) ) . '</strong></legend>';
@@ -130,6 +138,7 @@ class FormPostType {
         echo '</fieldset>';
     }
 
+    /** Render the payment metabox. */
     public static function render_payment_metabox( \WP_Post $post ): void {
         $defaults = [
             'amount'            => '21',
@@ -156,6 +165,7 @@ class FormPostType {
         echo '</select></label></p>';
     }
 
+    /** Render the email metabox. */
     public static function render_email_metabox( \WP_Post $post ): void {
         $defaults = [
             'welcome_url'      => '',
@@ -176,6 +186,7 @@ class FormPostType {
         echo '<textarea class="widefat" rows="6" name="wpbn_email[email_template]">' . esc_textarea( $values['email_template'] ) . '</textarea></label></p>';
     }
 
+    /** Render the GDPR metabox. */
     public static function render_gdpr_metabox( \WP_Post $post ): void {
         $defaults = [
             'gdpr_text'          => __( 'I consent to receive newsletters and accept the privacy policy.', 'wpbn' ),
@@ -194,6 +205,7 @@ class FormPostType {
         echo '<p><label>' . esc_html__( 'Data Retention (days, 0 = keep indefinitely)', 'wpbn' ) . ': <input type="number" min="0" name="wpbn_gdpr[retention_days]" value="' . esc_attr( $values['retention_days'] ) . '" /></label></p>';
     }
 
+    /** Render the provider override metabox. */
     public static function render_provider_metabox( \WP_Post $post ): void {
         $defaults = [
             'provider_override'     => '',
@@ -227,11 +239,18 @@ class FormPostType {
         echo '<p><label>' . esc_html__( 'ConvertKit Form ID (override)', 'wpbn' ) . '<br /><input type="text" class="widefat" name="wpbn_provider[convertkit_form_id]" value="' . esc_attr( $values['convertkit_form_id'] ) . '" /></label></p>';
     }
 
+    /** Render the shortcode helper metabox. */
     public static function render_shortcode_metabox( \WP_Post $post ): void {
         $shortcode = '[coinsnap_newsletter_form id="' . (int) $post->ID . '"]';
         echo '<input type="text" class="widefat" readonly value="' . esc_attr( $shortcode ) . '" onclick="this.select();" />';
     }
 
+    /**
+     * Save all metaboxes.
+     *
+     * @param int      $postId Post ID.
+     * @param \WP_Post $post   Post object.
+     */
     public static function save_meta( int $postId, \WP_Post $post ): void {
         if ( ! isset( $_POST['wpbn_form_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['wpbn_form_nonce'] ) ), 'wpbn_save_form_' . $postId ) ) {
             return;

--- a/wp-bitcoin-newsletter/src/Constants.php
+++ b/wp-bitcoin-newsletter/src/Constants.php
@@ -1,4 +1,10 @@
 <?php
+declare(strict_types=1);
+/**
+ * Constants container.
+ *
+ * @package wp-bitcoin-newsletter
+ */
 
 namespace WpBitcoinNewsletter;
 

--- a/wp-bitcoin-newsletter/src/Constants.php
+++ b/wp-bitcoin-newsletter/src/Constants.php
@@ -8,6 +8,11 @@ namespace WpBitcoinNewsletter;
 class Constants {
     /** REST namespace for the plugin. */
     public const REST_NAMESPACE = 'wpbn/v1';
+    public const REST_ROUTE_PAYMENT_COINSNAP = '/payment/coinsnap';
+    public const REST_ROUTE_PAYMENT_BTCPAY = '/payment/btcpay';
+    public const REST_ROUTE_STATUS = '/status/(?P<invoice>[^/]+)';
+    public const REST_ROUTE_RESYNC = '/subscribers/(?P<id>\\d+)/resync';
+    public const REST_ROUTE_BULK_RESYNC = '/subscribers/bulk-resync';
 
     /** CoinSnap endpoints (relative to API base). */
     public const COINSNAP_DEFAULT_API_BASE = 'https://api.coinsnap.io';
@@ -31,5 +36,8 @@ class Constants {
     public const SENDINBLUE_BASE = 'https://api.brevo.com/v3';
     public const SENDINBLUE_CONTACTS = '/contacts';
     public const SENDINBLUE_CONTACT = '/contacts/%s';
+
+    /** DB table suffixes. */
+    public const SUBSCRIBERS_TABLE_SUFFIX = 'wpbn_subscribers';
 }
 

--- a/wp-bitcoin-newsletter/src/Constants.php
+++ b/wp-bitcoin-newsletter/src/Constants.php
@@ -1,10 +1,10 @@
 <?php
-declare(strict_types=1);
 /**
  * Constants container.
  *
  * @package wp-bitcoin-newsletter
  */
+declare(strict_types=1);
 
 namespace WpBitcoinNewsletter;
 

--- a/wp-bitcoin-newsletter/src/Constants.php
+++ b/wp-bitcoin-newsletter/src/Constants.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace WpBitcoinNewsletter;
+
+/**
+ * Shared constants for endpoints and namespaces.
+ */
+class Constants {
+    /** REST namespace for the plugin. */
+    public const REST_NAMESPACE = 'wpbn/v1';
+
+    /** CoinSnap endpoints (relative to API base). */
+    public const COINSNAP_DEFAULT_API_BASE = 'https://api.coinsnap.io';
+    public const COINSNAP_INVOICES_ENDPOINT_V1 = '/api/v1/stores/%s/invoices';
+    public const COINSNAP_INVOICES_ENDPOINT_ALT = '/api/stores/%s/invoices';
+
+    /** CoinSnap API header names. */
+    public const COINSNAP_HEADER_API_KEY = 'X-Api-Key';
+
+    /** BTCPay endpoint (relative to host). */
+    public const BTCPAY_INVOICES_ENDPOINT = '/api/v1/stores/%s/invoices';
+
+    /** ConvertKit endpoint. */
+    public const CONVERTKIT_SUBSCRIBE_ENDPOINT = 'https://api.convertkit.com/v3/forms/%d/subscribe';
+
+    /** Mailchimp base and endpoints. */
+    public const MAILCHIMP_BASE = 'https://%s.api.mailchimp.com/3.0';
+    public const MAILCHIMP_MEMBER_ENDPOINT = '/lists/%s/members/%s';
+
+    /** Sendinblue/Brevo base and endpoints. */
+    public const SENDINBLUE_BASE = 'https://api.brevo.com/v3';
+    public const SENDINBLUE_CONTACTS = '/contacts';
+    public const SENDINBLUE_CONTACT = '/contacts/%s';
+}
+

--- a/wp-bitcoin-newsletter/src/Database/Installer.php
+++ b/wp-bitcoin-newsletter/src/Database/Installer.php
@@ -6,13 +6,25 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
+/**
+ * Database table installer and utilities.
+ */
 class Installer {
+    /**
+     * Get subscribers table name with prefix.
+     *
+     * @param \wpdb|null $wpdbParam Optional wpdb instance.
+     * @return string Table name.
+     */
     public static function tableName( $wpdbParam = null ): string {
         global $wpdb;
         $db = $wpdbParam ?: $wpdb;
         return $db->prefix . 'wpbn_subscribers';
     }
 
+    /**
+     * Activation callback to create/update DB schema.
+     */
     public static function activate(): void {
         global $wpdb;
         $table          = self::tableName( $wpdb );

--- a/wp-bitcoin-newsletter/src/Database/Installer.php
+++ b/wp-bitcoin-newsletter/src/Database/Installer.php
@@ -1,4 +1,10 @@
 <?php
+declare(strict_types=1);
+/**
+ * DB installer.
+ *
+ * @package wp-bitcoin-newsletter
+ */
 
 namespace WpBitcoinNewsletter\Database;
 
@@ -13,13 +19,23 @@ class Installer {
     /**
      * Get subscribers table name with prefix.
      *
-     * @param \wpdb|null $wpdbParam Optional wpdb instance.
+     * @param \wpdb|null $wpdb_param Optional wpdb instance.
      * @return string Table name.
      */
-    public static function tableName( $wpdbParam = null ): string {
+    public static function table_name( $wpdb_param = null ): string {
         global $wpdb;
-        $db = $wpdbParam ?: $wpdb;
+        $db = $wpdb_param ? $wpdb_param : $wpdb;
         return $db->prefix . \WpBitcoinNewsletter\Constants::SUBSCRIBERS_TABLE_SUFFIX;
+    }
+
+    /**
+     * Back-compat alias for camelCase method.
+     *
+     * @deprecated 0.2.0 Use table_name() instead.
+     * @phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+     */
+    public static function tableName( $wpdbParam = null ): string { // phpcs:ignore Squiz.NamingConventions.ValidFunctionName.NotCamelCaps
+        return self::table_name( $wpdbParam );
     }
 
     /**
@@ -28,7 +44,7 @@ class Installer {
     public static function activate(): void {
         global $wpdb;
         $table          = self::tableName( $wpdb );
-        $charsetCollate = $wpdb->get_charset_collate();
+        $charset_collate = $wpdb->get_charset_collate();
 
         require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 
@@ -58,7 +74,7 @@ class Installer {
             KEY email (email),
             KEY payment_status (payment_status),
             KEY provider_sync_status (provider_sync_status)
-        ) $charsetCollate;";
+        ) $charset_collate;";
 
         \dbDelta( $sql );
     }

--- a/wp-bitcoin-newsletter/src/Database/Installer.php
+++ b/wp-bitcoin-newsletter/src/Database/Installer.php
@@ -19,7 +19,7 @@ class Installer {
     public static function tableName( $wpdbParam = null ): string {
         global $wpdb;
         $db = $wpdbParam ?: $wpdb;
-        return $db->prefix . 'wpbn_subscribers';
+        return $db->prefix . \WpBitcoinNewsletter\Constants::SUBSCRIBERS_TABLE_SUFFIX;
     }
 
     /**

--- a/wp-bitcoin-newsletter/src/Database/Installer.php
+++ b/wp-bitcoin-newsletter/src/Database/Installer.php
@@ -2,21 +2,20 @@
 
 namespace WpBitcoinNewsletter\Database;
 
-defined('ABSPATH') || exit;
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
 
-class Installer
-{
-    public static function tableName($wpdbParam = null): string
-    {
+class Installer {
+    public static function tableName( $wpdbParam = null ): string {
         global $wpdb;
         $db = $wpdbParam ?: $wpdb;
         return $db->prefix . 'wpbn_subscribers';
     }
 
-    public static function activate(): void
-    {
+    public static function activate(): void {
         global $wpdb;
-        $table = self::tableName($wpdb);
+        $table          = self::tableName( $wpdb );
         $charsetCollate = $wpdb->get_charset_collate();
 
         require_once ABSPATH . 'wp-admin/includes/upgrade.php';
@@ -49,7 +48,7 @@ class Installer
             KEY provider_sync_status (provider_sync_status)
         ) $charsetCollate;";
 
-        \dbDelta($sql);
+        \dbDelta( $sql );
     }
 }
 

--- a/wp-bitcoin-newsletter/src/Database/Installer.php
+++ b/wp-bitcoin-newsletter/src/Database/Installer.php
@@ -1,10 +1,10 @@
 <?php
-declare(strict_types=1);
 /**
  * DB installer.
  *
  * @package wp-bitcoin-newsletter
  */
+declare(strict_types=1);
 
 namespace WpBitcoinNewsletter\Database;
 

--- a/wp-bitcoin-newsletter/src/Plugin.php
+++ b/wp-bitcoin-newsletter/src/Plugin.php
@@ -12,6 +12,9 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
+/**
+ * Main plugin bootstrap.
+ */
 class Plugin {
     /**
      * Singleton instance.
@@ -20,6 +23,11 @@ class Plugin {
      */
     private static $instance;
 
+    /**
+     * Get singleton instance.
+     *
+     * @return Plugin
+     */
     public static function instance(): Plugin {
         if ( ! self::$instance ) {
             self::$instance = new self();
@@ -27,6 +35,9 @@ class Plugin {
         return self::$instance;
     }
 
+    /**
+     * Register hooks on load.
+     */
     public function boot(): void {
         add_action( 'init', [ FormPostType::class, 'register' ] );
         add_action( 'init', [ FormShortcode::class, 'register' ] );
@@ -39,6 +50,9 @@ class Plugin {
         add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin' ] );
     }
 
+    /**
+     * Register admin menus and submenus.
+     */
     public function register_admin_menu(): void {
         add_menu_page(
             __( 'Newsletter Subscribers', 'wpbn' ),
@@ -60,12 +74,18 @@ class Plugin {
         );
     }
 
+    /**
+     * Register REST API routes.
+     */
     public function register_rest_routes(): void {
         RestRoutes::register();
     }
 
     
 
+    /**
+     * Enqueue frontend assets.
+     */
     public function enqueue_frontend(): void {
         wp_register_style( 'wpbn-frontend', WPBN_PLUGIN_URL . 'assets/css/frontend.css', [], WPBN_VERSION );
         wp_register_script( 'wpbn-frontend', WPBN_PLUGIN_URL . 'assets/js/frontend.js', [ 'jquery' ], WPBN_VERSION, true );
@@ -80,6 +100,9 @@ class Plugin {
         wp_enqueue_script( 'wpbn-frontend' );
     }
 
+    /**
+     * Enqueue admin assets.
+     */
     public function enqueue_admin(): void {
         wp_register_style( 'wpbn-admin', WPBN_PLUGIN_URL . 'assets/css/admin.css', [], WPBN_VERSION );
         wp_register_script( 'wpbn-admin', WPBN_PLUGIN_URL . 'assets/js/admin.js', [ 'jquery' ], WPBN_VERSION, true );

--- a/wp-bitcoin-newsletter/src/Plugin.php
+++ b/wp-bitcoin-newsletter/src/Plugin.php
@@ -7,6 +7,7 @@ use WpBitcoinNewsletter\Shortcode\FormShortcode;
 use WpBitcoinNewsletter\Admin\Settings as AdminSettings;
 use WpBitcoinNewsletter\Admin\SubscribersPage;
 use WpBitcoinNewsletter\Rest\Routes as RestRoutes;
+use WpBitcoinNewsletter\Constants;
 
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
@@ -92,7 +93,7 @@ class Plugin {
 
         wp_localize_script( 'wpbn-frontend', 'WPBN', [
             'ajaxUrl' => admin_url( 'admin-ajax.php' ),
-            'restUrl' => esc_url_raw( get_rest_url( null, 'wpbn/v1/' ) ),
+            'restUrl' => esc_url_raw( get_rest_url( null, Constants::REST_NAMESPACE . '/' ) ),
             'nonce'   => wp_create_nonce( 'wp_rest' ),
         ] );
 

--- a/wp-bitcoin-newsletter/src/Plugin.php
+++ b/wp-bitcoin-newsletter/src/Plugin.php
@@ -1,10 +1,10 @@
 <?php
-declare(strict_types=1);
 /**
  * Plugin core bootstrap.
  *
  * @package wp-bitcoin-newsletter
  */
+declare(strict_types=1);
 
 namespace WpBitcoinNewsletter;
 

--- a/wp-bitcoin-newsletter/src/Plugin.php
+++ b/wp-bitcoin-newsletter/src/Plugin.php
@@ -8,96 +8,94 @@ use WpBitcoinNewsletter\Admin\Settings as AdminSettings;
 use WpBitcoinNewsletter\Admin\SubscribersPage;
 use WpBitcoinNewsletter\Rest\Routes as RestRoutes;
 
-defined('ABSPATH') || exit;
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
 
-class Plugin
-{
-    /** @var Plugin|null */
+class Plugin {
+    /**
+     * Singleton instance.
+     *
+     * @var Plugin|null
+     */
     private static $instance;
 
-    public static function instance(): Plugin
-    {
-        if (!self::$instance) {
+    public static function instance(): Plugin {
+        if ( ! self::$instance ) {
             self::$instance = new self();
         }
         return self::$instance;
     }
 
-    public function boot(): void
-    {
-        add_action('init', [FormPostType::class, 'register']);
-        add_action('init', [FormShortcode::class, 'register']);
+    public function boot(): void {
+        add_action( 'init', [ FormPostType::class, 'register' ] );
+        add_action( 'init', [ FormShortcode::class, 'register' ] );
 
-        add_action('admin_menu', [$this, 'registerAdminMenu']);
+        add_action( 'admin_menu', [ $this, 'registerAdminMenu' ] );
         AdminSettings::register();
-        add_action('rest_api_init', [$this, 'registerRestRoutes']);
+        add_action( 'rest_api_init', [ $this, 'registerRestRoutes' ] );
 
-        add_action('wp_enqueue_scripts', [$this, 'enqueueFrontend']);
-        add_action('admin_enqueue_scripts', [$this, 'enqueueAdmin']);
+        add_action( 'wp_enqueue_scripts', [ $this, 'enqueueFrontend' ] );
+        add_action( 'admin_enqueue_scripts', [ $this, 'enqueueAdmin' ] );
     }
 
-    public function registerAdminMenu(): void
-    {
+    public function registerAdminMenu(): void {
         add_menu_page(
-            __('Newsletter Subscribers', 'wpbn'),
-            __('Subscribers', 'wpbn'),
+            __( 'Newsletter Subscribers', 'wpbn' ),
+            __( 'Subscribers', 'wpbn' ),
             'manage_options',
             'wpbn-subscribers',
-            [SubscribersPage::class, 'renderPage'],
+            [ SubscribersPage::class, 'renderPage' ],
             'dashicons-email',
             56
         );
 
         add_submenu_page(
             'wpbn-subscribers',
-            __('Settings', 'wpbn'),
-            __('Settings', 'wpbn'),
+            __( 'Settings', 'wpbn' ),
+            __( 'Settings', 'wpbn' ),
             'manage_options',
             'wpbn-settings',
-            [AdminSettings::class, 'renderPage']
+            [ AdminSettings::class, 'renderPage' ]
         );
     }
 
-    public function registerRestRoutes(): void
-    {
+    public function registerRestRoutes(): void {
         RestRoutes::register();
     }
 
-    // Simple test hook to simulate payment success when visiting ?wpbn_invoice=xyz
-    public function simulatePayment(): void
-    {
-        if (!is_admin() && isset($_GET['wpbn_invoice'])) {
-            $invoiceId = sanitize_text_field(wp_unslash($_GET['wpbn_invoice']));
-            $res = \WpBitcoinNewsletter\Services\SyncService::handlePaymentPaid($invoiceId);
-            if (!headers_sent() && !empty($res['redirect'])) {
-                wp_safe_redirect($res['redirect']);
+    // Simple test hook to simulate payment success when visiting ?wpbn_invoice=xyz.
+    public function simulatePayment(): void {
+        if ( ! is_admin() && isset( $_GET['wpbn_invoice'] ) ) {
+            $invoiceId = sanitize_text_field( wp_unslash( $_GET['wpbn_invoice'] ) );
+            $res       = \WpBitcoinNewsletter\Services\SyncService::handlePaymentPaid( $invoiceId );
+            if ( ! headers_sent() && ! empty( $res['redirect'] ) ) {
+                wp_safe_redirect( $res['redirect'] );
                 exit;
             }
         }
     }
 
-    public function enqueueFrontend(): void
-    {
-        wp_register_style('wpbn-frontend', WPBN_PLUGIN_URL . 'assets/css/frontend.css', [], WPBN_VERSION);
-        wp_register_script('wpbn-frontend', WPBN_PLUGIN_URL . 'assets/js/frontend.js', ['jquery'], WPBN_VERSION, true);
+    public function enqueueFrontend(): void {
+        wp_register_style( 'wpbn-frontend', WPBN_PLUGIN_URL . 'assets/css/frontend.css', [], WPBN_VERSION );
+        wp_register_script( 'wpbn-frontend', WPBN_PLUGIN_URL . 'assets/js/frontend.js', [ 'jquery' ], WPBN_VERSION, true );
 
-        wp_localize_script('wpbn-frontend', 'WPBN', [
-            'ajaxUrl' => admin_url('admin-ajax.php'),
-            'restUrl' => esc_url_raw(get_rest_url(null, 'wpbn/v1/')),
-            'nonce'   => wp_create_nonce('wp_rest')
-        ]);
+        wp_localize_script( 'wpbn-frontend', 'WPBN', [
+            'ajaxUrl' => admin_url( 'admin-ajax.php' ),
+            'restUrl' => esc_url_raw( get_rest_url( null, 'wpbn/v1/' ) ),
+            'nonce'   => wp_create_nonce( 'wp_rest' ),
+        ] );
 
-        wp_enqueue_style('wpbn-frontend');
-        wp_enqueue_script('wpbn-frontend');
+        wp_enqueue_style( 'wpbn-frontend' );
+        wp_enqueue_script( 'wpbn-frontend' );
     }
 
-    public function enqueueAdmin(): void
-    {
-        wp_register_style('wpbn-admin', WPBN_PLUGIN_URL . 'assets/css/admin.css', [], WPBN_VERSION);
-        wp_register_script('wpbn-admin', WPBN_PLUGIN_URL . 'assets/js/admin.js', ['jquery'], WPBN_VERSION, true);
+    public function enqueueAdmin(): void {
+        wp_register_style( 'wpbn-admin', WPBN_PLUGIN_URL . 'assets/css/admin.css', [], WPBN_VERSION );
+        wp_register_script( 'wpbn-admin', WPBN_PLUGIN_URL . 'assets/js/admin.js', [ 'jquery' ], WPBN_VERSION, true );
 
-        wp_enqueue_style('wpbn-admin');
-        wp_enqueue_script('wpbn-admin');
+        wp_enqueue_style( 'wpbn-admin' );
+        wp_enqueue_script( 'wpbn-admin' );
     }
 }
 

--- a/wp-bitcoin-newsletter/src/Plugin.php
+++ b/wp-bitcoin-newsletter/src/Plugin.php
@@ -31,21 +31,21 @@ class Plugin {
         add_action( 'init', [ FormPostType::class, 'register' ] );
         add_action( 'init', [ FormShortcode::class, 'register' ] );
 
-        add_action( 'admin_menu', [ $this, 'registerAdminMenu' ] );
+        add_action( 'admin_menu', [ $this, 'register_admin_menu' ] );
         AdminSettings::register();
-        add_action( 'rest_api_init', [ $this, 'registerRestRoutes' ] );
+        add_action( 'rest_api_init', [ $this, 'register_rest_routes' ] );
 
-        add_action( 'wp_enqueue_scripts', [ $this, 'enqueueFrontend' ] );
-        add_action( 'admin_enqueue_scripts', [ $this, 'enqueueAdmin' ] );
+        add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_frontend' ] );
+        add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin' ] );
     }
 
-    public function registerAdminMenu(): void {
+    public function register_admin_menu(): void {
         add_menu_page(
             __( 'Newsletter Subscribers', 'wpbn' ),
             __( 'Subscribers', 'wpbn' ),
             'manage_options',
             'wpbn-subscribers',
-            [ SubscribersPage::class, 'renderPage' ],
+            [ SubscribersPage::class, 'render_page' ],
             'dashicons-email',
             56
         );
@@ -56,16 +56,16 @@ class Plugin {
             __( 'Settings', 'wpbn' ),
             'manage_options',
             'wpbn-settings',
-            [ AdminSettings::class, 'renderPage' ]
+            [ AdminSettings::class, 'render_page' ]
         );
     }
 
-    public function registerRestRoutes(): void {
+    public function register_rest_routes(): void {
         RestRoutes::register();
     }
 
     // Simple test hook to simulate payment success when visiting ?wpbn_invoice=xyz.
-    public function simulatePayment(): void {
+    public function simulate_payment(): void {
         if ( ! is_admin() && isset( $_GET['wpbn_invoice'] ) ) {
             $invoiceId = sanitize_text_field( wp_unslash( $_GET['wpbn_invoice'] ) );
             $res       = \WpBitcoinNewsletter\Services\SyncService::handlePaymentPaid( $invoiceId );
@@ -76,7 +76,7 @@ class Plugin {
         }
     }
 
-    public function enqueueFrontend(): void {
+    public function enqueue_frontend(): void {
         wp_register_style( 'wpbn-frontend', WPBN_PLUGIN_URL . 'assets/css/frontend.css', [], WPBN_VERSION );
         wp_register_script( 'wpbn-frontend', WPBN_PLUGIN_URL . 'assets/js/frontend.js', [ 'jquery' ], WPBN_VERSION, true );
 
@@ -90,7 +90,7 @@ class Plugin {
         wp_enqueue_script( 'wpbn-frontend' );
     }
 
-    public function enqueueAdmin(): void {
+    public function enqueue_admin(): void {
         wp_register_style( 'wpbn-admin', WPBN_PLUGIN_URL . 'assets/css/admin.css', [], WPBN_VERSION );
         wp_register_script( 'wpbn-admin', WPBN_PLUGIN_URL . 'assets/js/admin.js', [ 'jquery' ], WPBN_VERSION, true );
 

--- a/wp-bitcoin-newsletter/src/Plugin.php
+++ b/wp-bitcoin-newsletter/src/Plugin.php
@@ -1,4 +1,10 @@
 <?php
+declare(strict_types=1);
+/**
+ * Plugin core bootstrap.
+ *
+ * @package wp-bitcoin-newsletter
+ */
 
 namespace WpBitcoinNewsletter;
 

--- a/wp-bitcoin-newsletter/src/Plugin.php
+++ b/wp-bitcoin-newsletter/src/Plugin.php
@@ -64,17 +64,7 @@ class Plugin {
         RestRoutes::register();
     }
 
-    // Simple test hook to simulate payment success when visiting ?wpbn_invoice=xyz.
-    public function simulate_payment(): void {
-        if ( ! is_admin() && isset( $_GET['wpbn_invoice'] ) ) {
-            $invoiceId = sanitize_text_field( wp_unslash( $_GET['wpbn_invoice'] ) );
-            $res       = \WpBitcoinNewsletter\Services\SyncService::handlePaymentPaid( $invoiceId );
-            if ( ! headers_sent() && ! empty( $res['redirect'] ) ) {
-                wp_safe_redirect( $res['redirect'] );
-                exit;
-            }
-        }
-    }
+    
 
     public function enqueue_frontend(): void {
         wp_register_style( 'wpbn-frontend', WPBN_PLUGIN_URL . 'assets/css/frontend.css', [], WPBN_VERSION );

--- a/wp-bitcoin-newsletter/src/Providers/Newsletter/ConvertKitProvider.php
+++ b/wp-bitcoin-newsletter/src/Providers/Newsletter/ConvertKitProvider.php
@@ -13,7 +13,8 @@ class ConvertKitProvider implements NewsletterProviderInterface {
         if ( ! $apiSecret || ! $formId ) {
             return false;
         }
-        $url     = 'https://api.convertkit.com/v3/forms/' . $formId . '/subscribe';
+        $url     = \WpBitcoinNewsletter\Constants::CONVERTKIT_SUBSCRIBE_ENDPOINT;
+        $url     = sprintf( $url, $formId );
         $payload = [
             'api_secret' => $apiSecret,
             'email'      => (string) $subscriber['email'],

--- a/wp-bitcoin-newsletter/src/Providers/Newsletter/ConvertKitProvider.php
+++ b/wp-bitcoin-newsletter/src/Providers/Newsletter/ConvertKitProvider.php
@@ -1,10 +1,10 @@
 <?php
-declare(strict_types=1);
 /**
  * ConvertKit provider.
  *
  * @package wp-bitcoin-newsletter
  */
+declare(strict_types=1);
 
 namespace WpBitcoinNewsletter\Providers\Newsletter;
 

--- a/wp-bitcoin-newsletter/src/Providers/Newsletter/ConvertKitProvider.php
+++ b/wp-bitcoin-newsletter/src/Providers/Newsletter/ConvertKitProvider.php
@@ -1,4 +1,10 @@
 <?php
+declare(strict_types=1);
+/**
+ * ConvertKit provider.
+ *
+ * @package wp-bitcoin-newsletter
+ */
 
 namespace WpBitcoinNewsletter\Providers\Newsletter;
 

--- a/wp-bitcoin-newsletter/src/Providers/Newsletter/ConvertKitProvider.php
+++ b/wp-bitcoin-newsletter/src/Providers/Newsletter/ConvertKitProvider.php
@@ -2,43 +2,48 @@
 
 namespace WpBitcoinNewsletter\Providers\Newsletter;
 
-class ConvertKitProvider implements NewsletterProviderInterface
-{
-    public function upsert(array $subscriber, array $options = []): bool
-    {
-        $apiSecret = (string)($options['convertkit_api_secret'] ?? '');
-        $formId = (int)($options['convertkit_form_id'] ?? 0);
-        if (!$apiSecret || !$formId) return false;
-        $url = 'https://api.convertkit.com/v3/forms/' . $formId . '/subscribe';
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class ConvertKitProvider implements NewsletterProviderInterface {
+    public function upsert( array $subscriber, array $options = [] ): bool {
+        $apiSecret = (string) ( $options['convertkit_api_secret'] ?? '' );
+        $formId    = (int) ( $options['convertkit_form_id'] ?? 0 );
+        if ( ! $apiSecret || ! $formId ) {
+            return false;
+        }
+        $url     = 'https://api.convertkit.com/v3/forms/' . $formId . '/subscribe';
         $payload = [
             'api_secret' => $apiSecret,
-            'email' => (string)$subscriber['email'],
-            'first_name' => (string)($subscriber['first_name'] ?? ''),
-            'fields' => [
-                'last_name' => (string)($subscriber['last_name'] ?? ''),
-                'phone' => (string)($subscriber['phone'] ?? ''),
-                'company' => (string)($subscriber['company'] ?? ''),
-                'custom1' => (string)($subscriber['custom1'] ?? ''),
-                'custom2' => (string)($subscriber['custom2'] ?? ''),
+            'email'      => (string) $subscriber['email'],
+            'first_name' => (string) ( $subscriber['first_name'] ?? '' ),
+            'fields'     => [
+                'last_name' => (string) ( $subscriber['last_name'] ?? '' ),
+                'phone'     => (string) ( $subscriber['phone'] ?? '' ),
+                'company'   => (string) ( $subscriber['company'] ?? '' ),
+                'custom1'   => (string) ( $subscriber['custom1'] ?? '' ),
+                'custom2'   => (string) ( $subscriber['custom2'] ?? '' ),
             ],
         ];
         $args = [
-            'method' => 'POST',
+            'method'  => 'POST',
             'headers' => [
                 'Content-Type' => 'application/json',
-                'accept' => 'application/json',
+                'accept'       => 'application/json',
             ],
             'timeout' => 20,
-            'body' => wp_json_encode($payload),
+            'body'    => wp_json_encode( $payload ),
         ];
-        $res = wp_remote_request($url, $args);
-        if (is_wp_error($res)) return false;
-        $code = wp_remote_retrieve_response_code($res);
+        $res = wp_remote_request( $url, $args );
+        if ( is_wp_error( $res ) ) {
+            return false;
+        }
+        $code = wp_remote_retrieve_response_code( $res );
         return $code >= 200 && $code < 300;
     }
 
-    public function unsubscribe(string $email, array $options = []): bool
-    {
+    public function unsubscribe( string $email, array $options = [] ): bool {
         // ConvertKit requires unsubscribing from sequences/tags; non-trivial here.
         return true;
     }

--- a/wp-bitcoin-newsletter/src/Providers/Newsletter/DbProvider.php
+++ b/wp-bitcoin-newsletter/src/Providers/Newsletter/DbProvider.php
@@ -2,17 +2,18 @@
 
 namespace WpBitcoinNewsletter\Providers\Newsletter;
 
-class DbProvider implements NewsletterProviderInterface
-{
-    public function upsert(array $subscriber, array $options = []): bool
-    {
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class DbProvider implements NewsletterProviderInterface {
+    public function upsert( array $subscriber, array $options = [] ): bool {
         // Internal storage already handled by plugin DB. Nothing to do.
         return true;
     }
 
-    public function unsubscribe(string $email, array $options = []): bool
-    {
-        // Defer to WordPress-level unsubscribe handling if applicable
+    public function unsubscribe( string $email, array $options = [] ): bool {
+        // Defer to WordPress-level unsubscribe handling if applicable.
         return true;
     }
 }

--- a/wp-bitcoin-newsletter/src/Providers/Newsletter/DbProvider.php
+++ b/wp-bitcoin-newsletter/src/Providers/Newsletter/DbProvider.php
@@ -6,12 +6,17 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
+/**
+ * Internal DB provider (no external sync required).
+ */
 class DbProvider implements NewsletterProviderInterface {
+    /** @inheritDoc */
     public function upsert( array $subscriber, array $options = [] ): bool {
         // Internal storage already handled by plugin DB. Nothing to do.
         return true;
     }
 
+    /** @inheritDoc */
     public function unsubscribe( string $email, array $options = [] ): bool {
         // Defer to WordPress-level unsubscribe handling if applicable.
         return true;

--- a/wp-bitcoin-newsletter/src/Providers/Newsletter/MailPoetProvider.php
+++ b/wp-bitcoin-newsletter/src/Providers/Newsletter/MailPoetProvider.php
@@ -1,4 +1,10 @@
 <?php
+declare(strict_types=1);
+/**
+ * MailPoet provider.
+ *
+ * @package wp-bitcoin-newsletter
+ */
 
 namespace WpBitcoinNewsletter\Providers\Newsletter;
 

--- a/wp-bitcoin-newsletter/src/Providers/Newsletter/MailPoetProvider.php
+++ b/wp-bitcoin-newsletter/src/Providers/Newsletter/MailPoetProvider.php
@@ -2,56 +2,59 @@
 
 namespace WpBitcoinNewsletter\Providers\Newsletter;
 
-class MailPoetProvider implements NewsletterProviderInterface
-{
-    public function upsert(array $subscriber, array $options = []): bool
-    {
-        if (!class_exists('MailPoet\\API\\API')) {
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class MailPoetProvider implements NewsletterProviderInterface {
+    public function upsert( array $subscriber, array $options = [] ): bool {
+        if ( ! class_exists( 'MailPoet\\API\\API' ) ) {
             return false;
         }
-        $listId = isset($options['mailpoet_list_id']) ? (int)$options['mailpoet_list_id'] : 0;
-        if (!$listId) return false;
+        $listId = isset( $options['mailpoet_list_id'] ) ? (int) $options['mailpoet_list_id'] : 0;
+        if ( ! $listId ) {
+            return false;
+        }
 
-        $api = \MailPoet\API\API::MP('v1');
-        $status = !empty($options['double_opt_in']) ? 'unconfirmed' : 'subscribed';
-        $data = [
-            'email' => (string)$subscriber['email'],
-            'first_name' => (string)($subscriber['first_name'] ?? ''),
-            'last_name' => (string)($subscriber['last_name'] ?? ''),
-            'status' => $status,
+        $api    = \MailPoet\API\API::MP( 'v1' );
+        $status = ! empty( $options['double_opt_in'] ) ? 'unconfirmed' : 'subscribed';
+        $data   = [
+            'email'      => (string) $subscriber['email'],
+            'first_name' => (string) ( $subscriber['first_name'] ?? '' ),
+            'last_name'  => (string) ( $subscriber['last_name'] ?? '' ),
+            'status'     => $status,
         ];
         try {
-            $api->addSubscriber($data, [$listId]);
+            $api->addSubscriber( $data, [ $listId ] );
             return true;
-        } catch (\Throwable $e) {
-            // Try update if exists
+        } catch ( \Throwable $e ) {
+            // Try update if exists.
             try {
-                $existing = $api->getSubscriber($data['email']);
-                if ($existing && !empty($existing['id'])) {
-                    $api->subscribeToList($existing['id'], $listId);
-                    if ($status === 'subscribed') {
-                        $api->subscribe($existing['id']);
+                $existing = $api->getSubscriber( $data['email'] );
+                if ( $existing && ! empty( $existing['id'] ) ) {
+                    $api->subscribeToList( $existing['id'], $listId );
+                    if ( $status === 'subscribed' ) {
+                        $api->subscribe( $existing['id'] );
                     }
                     return true;
                 }
-            } catch (\Throwable $e2) {}
+            } catch ( \Throwable $e2 ) {}
         }
         return false;
     }
 
-    public function unsubscribe(string $email, array $options = []): bool
-    {
-        if (!class_exists('MailPoet\\API\\API')) {
+    public function unsubscribe( string $email, array $options = [] ): bool {
+        if ( ! class_exists( 'MailPoet\\API\\API' ) ) {
             return false;
         }
         try {
-            $api = \MailPoet\API\API::MP('v1');
-            $sub = $api->getSubscriber($email);
-            if ($sub && !empty($sub['id'])) {
-                $api->unsubscribe($sub['id']);
+            $api = \MailPoet\API\API::MP( 'v1' );
+            $sub = $api->getSubscriber( $email );
+            if ( $sub && ! empty( $sub['id'] ) ) {
+                $api->unsubscribe( $sub['id'] );
                 return true;
             }
-        } catch (\Throwable $e) {}
+        } catch ( \Throwable $e ) {}
         return false;
     }
 }

--- a/wp-bitcoin-newsletter/src/Providers/Newsletter/MailPoetProvider.php
+++ b/wp-bitcoin-newsletter/src/Providers/Newsletter/MailPoetProvider.php
@@ -6,7 +6,11 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
+/**
+ * MailPoet newsletter provider implementation.
+ */
 class MailPoetProvider implements NewsletterProviderInterface {
+    /** @inheritDoc */
     public function upsert( array $subscriber, array $options = [] ): bool {
         if ( ! class_exists( 'MailPoet\\API\\API' ) ) {
             return false;
@@ -43,6 +47,7 @@ class MailPoetProvider implements NewsletterProviderInterface {
         return false;
     }
 
+    /** @inheritDoc */
     public function unsubscribe( string $email, array $options = [] ): bool {
         if ( ! class_exists( 'MailPoet\\API\\API' ) ) {
             return false;

--- a/wp-bitcoin-newsletter/src/Providers/Newsletter/MailPoetProvider.php
+++ b/wp-bitcoin-newsletter/src/Providers/Newsletter/MailPoetProvider.php
@@ -1,10 +1,10 @@
 <?php
-declare(strict_types=1);
 /**
  * MailPoet provider.
  *
  * @package wp-bitcoin-newsletter
  */
+declare(strict_types=1);
 
 namespace WpBitcoinNewsletter\Providers\Newsletter;
 

--- a/wp-bitcoin-newsletter/src/Providers/Newsletter/MailchimpProvider.php
+++ b/wp-bitcoin-newsletter/src/Providers/Newsletter/MailchimpProvider.php
@@ -1,10 +1,10 @@
 <?php
-declare(strict_types=1);
 /**
  * Mailchimp provider.
  *
  * @package wp-bitcoin-newsletter
  */
+declare(strict_types=1);
 
 namespace WpBitcoinNewsletter\Providers\Newsletter;
 

--- a/wp-bitcoin-newsletter/src/Providers/Newsletter/MailchimpProvider.php
+++ b/wp-bitcoin-newsletter/src/Providers/Newsletter/MailchimpProvider.php
@@ -23,7 +23,8 @@ class MailchimpProvider implements NewsletterProviderInterface {
         }
         $email  = strtolower( trim( (string) $subscriber['email'] ) );
         $hash   = md5( $email );
-        $url    = 'https://' . $dc . '.api.mailchimp.com/3.0/lists/' . rawurlencode( $audienceId ) . '/members/' . $hash;
+        $base   = sprintf( \WpBitcoinNewsletter\Constants::MAILCHIMP_BASE, $dc );
+        $url    = $base . sprintf( \WpBitcoinNewsletter\Constants::MAILCHIMP_MEMBER_ENDPOINT, rawurlencode( $audienceId ), $hash );
         $status = ! empty( $options['double_opt_in'] ) ? 'pending' : 'subscribed';
         $body   = [
             'email_address' => $email,
@@ -64,7 +65,8 @@ class MailchimpProvider implements NewsletterProviderInterface {
         }
         $emailLower = strtolower( trim( $email ) );
         $hash       = md5( $emailLower );
-        $url        = 'https://' . $dc . '.api.mailchimp.com/3.0/lists/' . rawurlencode( $audienceId ) . '/members/' . $hash;
+        $base       = sprintf( \WpBitcoinNewsletter\Constants::MAILCHIMP_BASE, $dc );
+        $url        = $base . sprintf( \WpBitcoinNewsletter\Constants::MAILCHIMP_MEMBER_ENDPOINT, rawurlencode( $audienceId ), $hash );
         $body       = [ 'status' => 'unsubscribed' ];
         $args       = [
             'method'  => 'PATCH',

--- a/wp-bitcoin-newsletter/src/Providers/Newsletter/MailchimpProvider.php
+++ b/wp-bitcoin-newsletter/src/Providers/Newsletter/MailchimpProvider.php
@@ -2,66 +2,79 @@
 
 namespace WpBitcoinNewsletter\Providers\Newsletter;
 
-class MailchimpProvider implements NewsletterProviderInterface
-{
-    public function upsert(array $subscriber, array $options = []): bool
-    {
-        $apiKey = (string)($options['mailchimp_api_key'] ?? '');
-        $audienceId = (string)($options['mailchimp_audience_id'] ?? '');
-        if (!$apiKey || !$audienceId) return false;
-        $dc = substr($apiKey, strpos($apiKey, '-') + 1);
-        if (!$dc) return false;
-        $email = strtolower(trim((string)$subscriber['email']));
-        $hash = md5($email);
-        $url = 'https://' . $dc . '.api.mailchimp.com/3.0/lists/' . rawurlencode($audienceId) . '/members/' . $hash;
-        $status = !empty($options['double_opt_in']) ? 'pending' : 'subscribed';
-        $body = [
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class MailchimpProvider implements NewsletterProviderInterface {
+    public function upsert( array $subscriber, array $options = [] ): bool {
+        $apiKey     = (string) ( $options['mailchimp_api_key'] ?? '' );
+        $audienceId = (string) ( $options['mailchimp_audience_id'] ?? '' );
+        if ( ! $apiKey || ! $audienceId ) {
+            return false;
+        }
+        $dc = substr( $apiKey, strpos( $apiKey, '-' ) + 1 );
+        if ( ! $dc ) {
+            return false;
+        }
+        $email  = strtolower( trim( (string) $subscriber['email'] ) );
+        $hash   = md5( $email );
+        $url    = 'https://' . $dc . '.api.mailchimp.com/3.0/lists/' . rawurlencode( $audienceId ) . '/members/' . $hash;
+        $status = ! empty( $options['double_opt_in'] ) ? 'pending' : 'subscribed';
+        $body   = [
             'email_address' => $email,
             'status_if_new' => $status,
-            'status' => $status,
-            'merge_fields' => [
-                'FNAME' => (string)($subscriber['first_name'] ?? ''),
-                'LNAME' => (string)($subscriber['last_name'] ?? ''),
+            'status'        => $status,
+            'merge_fields'  => [
+                'FNAME' => (string) ( $subscriber['first_name'] ?? '' ),
+                'LNAME' => (string) ( $subscriber['last_name'] ?? '' ),
             ],
         ];
         $args = [
-            'method' => 'PUT',
+            'method'  => 'PUT',
             'headers' => [
-                'Authorization' => 'Basic ' . base64_encode('any:' . $apiKey),
-                'Content-Type' => 'application/json',
+                'Authorization' => 'Basic ' . base64_encode( 'any:' . $apiKey ),
+                'Content-Type'  => 'application/json',
             ],
             'timeout' => 15,
-            'body' => wp_json_encode($body),
+            'body'    => wp_json_encode( $body ),
         ];
-        $res = wp_remote_request($url, $args);
-        if (is_wp_error($res)) return false;
-        $code = wp_remote_retrieve_response_code($res);
+        $res = wp_remote_request( $url, $args );
+        if ( is_wp_error( $res ) ) {
+            return false;
+        }
+        $code = wp_remote_retrieve_response_code( $res );
         return $code >= 200 && $code < 300;
     }
 
-    public function unsubscribe(string $email, array $options = []): bool
-    {
-        $apiKey = (string)($options['mailchimp_api_key'] ?? '');
-        $audienceId = (string)($options['mailchimp_audience_id'] ?? '');
-        if (!$apiKey || !$audienceId) return false;
-        $dc = substr($apiKey, strpos($apiKey, '-') + 1);
-        if (!$dc) return false;
-        $emailLower = strtolower(trim($email));
-        $hash = md5($emailLower);
-        $url = 'https://' . $dc . '.api.mailchimp.com/3.0/lists/' . rawurlencode($audienceId) . '/members/' . $hash;
-        $body = ['status' => 'unsubscribed'];
-        $args = [
-            'method' => 'PATCH',
+    public function unsubscribe( string $email, array $options = [] ): bool {
+        $apiKey     = (string) ( $options['mailchimp_api_key'] ?? '' );
+        $audienceId = (string) ( $options['mailchimp_audience_id'] ?? '' );
+        if ( ! $apiKey || ! $audienceId ) {
+            return false;
+        }
+        $dc = substr( $apiKey, strpos( $apiKey, '-' ) + 1 );
+        if ( ! $dc ) {
+            return false;
+        }
+        $emailLower = strtolower( trim( $email ) );
+        $hash       = md5( $emailLower );
+        $url        = 'https://' . $dc . '.api.mailchimp.com/3.0/lists/' . rawurlencode( $audienceId ) . '/members/' . $hash;
+        $body       = [ 'status' => 'unsubscribed' ];
+        $args       = [
+            'method'  => 'PATCH',
             'headers' => [
-                'Authorization' => 'Basic ' . base64_encode('any:' . $apiKey),
-                'Content-Type' => 'application/json',
+                'Authorization' => 'Basic ' . base64_encode( 'any:' . $apiKey ),
+                'Content-Type'  => 'application/json',
             ],
             'timeout' => 15,
-            'body' => wp_json_encode($body),
+            'body'    => wp_json_encode( $body ),
         ];
-        $res = wp_remote_request($url, $args);
-        if (is_wp_error($res)) return false;
-        $code = wp_remote_retrieve_response_code($res);
+        $res = wp_remote_request( $url, $args );
+        if ( is_wp_error( $res ) ) {
+            return false;
+        }
+        $code = wp_remote_retrieve_response_code( $res );
         return $code >= 200 && $code < 300;
     }
 }

--- a/wp-bitcoin-newsletter/src/Providers/Newsletter/MailchimpProvider.php
+++ b/wp-bitcoin-newsletter/src/Providers/Newsletter/MailchimpProvider.php
@@ -6,7 +6,11 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
+/**
+ * Mailchimp newsletter provider implementation.
+ */
 class MailchimpProvider implements NewsletterProviderInterface {
+    /** @inheritDoc */
     public function upsert( array $subscriber, array $options = [] ): bool {
         $apiKey     = (string) ( $options['mailchimp_api_key'] ?? '' );
         $audienceId = (string) ( $options['mailchimp_audience_id'] ?? '' );
@@ -47,6 +51,7 @@ class MailchimpProvider implements NewsletterProviderInterface {
         return $code >= 200 && $code < 300;
     }
 
+    /** @inheritDoc */
     public function unsubscribe( string $email, array $options = [] ): bool {
         $apiKey     = (string) ( $options['mailchimp_api_key'] ?? '' );
         $audienceId = (string) ( $options['mailchimp_audience_id'] ?? '' );

--- a/wp-bitcoin-newsletter/src/Providers/Newsletter/MailchimpProvider.php
+++ b/wp-bitcoin-newsletter/src/Providers/Newsletter/MailchimpProvider.php
@@ -1,4 +1,10 @@
 <?php
+declare(strict_types=1);
+/**
+ * Mailchimp provider.
+ *
+ * @package wp-bitcoin-newsletter
+ */
 
 namespace WpBitcoinNewsletter\Providers\Newsletter;
 

--- a/wp-bitcoin-newsletter/src/Providers/Newsletter/NewsletterProviderInterface.php
+++ b/wp-bitcoin-newsletter/src/Providers/Newsletter/NewsletterProviderInterface.php
@@ -1,4 +1,10 @@
 <?php
+declare(strict_types=1);
+/**
+ * Newsletter provider interface.
+ *
+ * @package wp-bitcoin-newsletter
+ */
 
 namespace WpBitcoinNewsletter\Providers\Newsletter;
 

--- a/wp-bitcoin-newsletter/src/Providers/Newsletter/NewsletterProviderInterface.php
+++ b/wp-bitcoin-newsletter/src/Providers/Newsletter/NewsletterProviderInterface.php
@@ -1,10 +1,10 @@
 <?php
-declare(strict_types=1);
 /**
  * Newsletter provider interface.
  *
  * @package wp-bitcoin-newsletter
  */
+declare(strict_types=1);
 
 namespace WpBitcoinNewsletter\Providers\Newsletter;
 

--- a/wp-bitcoin-newsletter/src/Providers/Newsletter/NewsletterProviderInterface.php
+++ b/wp-bitcoin-newsletter/src/Providers/Newsletter/NewsletterProviderInterface.php
@@ -2,12 +2,11 @@
 
 namespace WpBitcoinNewsletter\Providers\Newsletter;
 
-interface NewsletterProviderInterface
-{
+interface NewsletterProviderInterface {
     /** Create or update a subscriber; return true on success */
-    public function upsert(array $subscriber, array $options = []): bool;
+    public function upsert( array $subscriber, array $options = [] ): bool;
 
     /** Handle unsubscribe if applicable */
-    public function unsubscribe(string $email, array $options = []): bool;
+    public function unsubscribe( string $email, array $options = [] ): bool;
 }
 

--- a/wp-bitcoin-newsletter/src/Providers/Newsletter/NewsletterProviderInterface.php
+++ b/wp-bitcoin-newsletter/src/Providers/Newsletter/NewsletterProviderInterface.php
@@ -2,11 +2,26 @@
 
 namespace WpBitcoinNewsletter\Providers\Newsletter;
 
+/**
+ * Newsletter providers must support upsert and unsubscribe.
+ */
 interface NewsletterProviderInterface {
-    /** Create or update a subscriber; return true on success */
+    /**
+     * Create or update a subscriber.
+     *
+     * @param array $subscriber Subscriber fields.
+     * @param array $options    Provider-specific options.
+     * @return bool True on success.
+     */
     public function upsert( array $subscriber, array $options = [] ): bool;
 
-    /** Handle unsubscribe if applicable */
+    /**
+     * Unsubscribe an email address.
+     *
+     * @param string $email   Email address.
+     * @param array  $options Provider-specific options.
+     * @return bool True on success.
+     */
     public function unsubscribe( string $email, array $options = [] ): bool;
 }
 

--- a/wp-bitcoin-newsletter/src/Providers/Newsletter/SendinblueProvider.php
+++ b/wp-bitcoin-newsletter/src/Providers/Newsletter/SendinblueProvider.php
@@ -1,10 +1,10 @@
 <?php
-declare(strict_types=1);
 /**
  * Sendinblue/Brevo provider.
  *
  * @package wp-bitcoin-newsletter
  */
+declare(strict_types=1);
 
 namespace WpBitcoinNewsletter\Providers\Newsletter;
 

--- a/wp-bitcoin-newsletter/src/Providers/Newsletter/SendinblueProvider.php
+++ b/wp-bitcoin-newsletter/src/Providers/Newsletter/SendinblueProvider.php
@@ -2,60 +2,69 @@
 
 namespace WpBitcoinNewsletter\Providers\Newsletter;
 
-class SendinblueProvider implements NewsletterProviderInterface
-{
-    public function upsert(array $subscriber, array $options = []): bool
-    {
-        $apiKey = (string)($options['sendinblue_api_key'] ?? '');
-        $listId = (int)($options['sendinblue_list_id'] ?? 0);
-        if (!$apiKey || !$listId) return false;
-        $url = 'https://api.brevo.com/v3/contacts';
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class SendinblueProvider implements NewsletterProviderInterface {
+    public function upsert( array $subscriber, array $options = [] ): bool {
+        $apiKey = (string) ( $options['sendinblue_api_key'] ?? '' );
+        $listId = (int) ( $options['sendinblue_list_id'] ?? 0 );
+        if ( ! $apiKey || ! $listId ) {
+            return false;
+        }
+        $url     = 'https://api.brevo.com/v3/contacts';
         $payload = [
-            'email' => (string)$subscriber['email'],
+            'email'      => (string) $subscriber['email'],
             'attributes' => [
-                'FIRSTNAME' => (string)($subscriber['first_name'] ?? ''),
-                'LASTNAME' => (string)($subscriber['last_name'] ?? ''),
-                'SMS' => (string)($subscriber['phone'] ?? ''),
-                'COMPANY' => (string)($subscriber['company'] ?? ''),
+                'FIRSTNAME' => (string) ( $subscriber['first_name'] ?? '' ),
+                'LASTNAME'  => (string) ( $subscriber['last_name'] ?? '' ),
+                'SMS'       => (string) ( $subscriber['phone'] ?? '' ),
+                'COMPANY'   => (string) ( $subscriber['company'] ?? '' ),
             ],
-            'listIds' => [$listId],
+            'listIds'       => [ $listId ],
             'updateEnabled' => true,
         ];
         $args = [
-            'method' => 'POST',
+            'method'  => 'POST',
             'headers' => [
-                'api-key' => $apiKey,
+                'api-key'      => $apiKey,
                 'Content-Type' => 'application/json',
-                'accept' => 'application/json',
+                'accept'       => 'application/json',
             ],
             'timeout' => 20,
-            'body' => wp_json_encode($payload),
+            'body'    => wp_json_encode( $payload ),
         ];
-        $res = wp_remote_request($url, $args);
-        if (is_wp_error($res)) return false;
-        $code = wp_remote_retrieve_response_code($res);
+        $res = wp_remote_request( $url, $args );
+        if ( is_wp_error( $res ) ) {
+            return false;
+        }
+        $code = wp_remote_retrieve_response_code( $res );
         return $code >= 200 && $code < 300;
     }
 
-    public function unsubscribe(string $email, array $options = []): bool
-    {
-        $apiKey = (string)($options['sendinblue_api_key'] ?? '');
-        if (!$apiKey) return false;
-        $url = 'https://api.brevo.com/v3/contacts/' . rawurlencode(strtolower(trim($email)));
+    public function unsubscribe( string $email, array $options = [] ): bool {
+        $apiKey = (string) ( $options['sendinblue_api_key'] ?? '' );
+        if ( ! $apiKey ) {
+            return false;
+        }
+        $url     = 'https://api.brevo.com/v3/contacts/' . rawurlencode( strtolower( trim( $email ) ) );
         $payload = [ 'unlinkListIds' => [] ];
-        $args = [
-            'method' => 'PUT',
+        $args    = [
+            'method'  => 'PUT',
             'headers' => [
-                'api-key' => $apiKey,
+                'api-key'      => $apiKey,
                 'Content-Type' => 'application/json',
-                'accept' => 'application/json',
+                'accept'       => 'application/json',
             ],
             'timeout' => 20,
-            'body' => wp_json_encode($payload),
+            'body'    => wp_json_encode( $payload ),
         ];
-        $res = wp_remote_request($url, $args);
-        if (is_wp_error($res)) return false;
-        $code = wp_remote_retrieve_response_code($res);
+        $res = wp_remote_request( $url, $args );
+        if ( is_wp_error( $res ) ) {
+            return false;
+        }
+        $code = wp_remote_retrieve_response_code( $res );
         return $code >= 200 && $code < 300;
     }
 }

--- a/wp-bitcoin-newsletter/src/Providers/Newsletter/SendinblueProvider.php
+++ b/wp-bitcoin-newsletter/src/Providers/Newsletter/SendinblueProvider.php
@@ -17,7 +17,7 @@ class SendinblueProvider implements NewsletterProviderInterface {
         if ( ! $apiKey || ! $listId ) {
             return false;
         }
-        $url     = 'https://api.brevo.com/v3/contacts';
+        $url     = \WpBitcoinNewsletter\Constants::SENDINBLUE_BASE . \WpBitcoinNewsletter\Constants::SENDINBLUE_CONTACTS;
         $payload = [
             'email'      => (string) $subscriber['email'],
             'attributes' => [
@@ -53,7 +53,7 @@ class SendinblueProvider implements NewsletterProviderInterface {
         if ( ! $apiKey ) {
             return false;
         }
-        $url     = 'https://api.brevo.com/v3/contacts/' . rawurlencode( strtolower( trim( $email ) ) );
+        $url     = \WpBitcoinNewsletter\Constants::SENDINBLUE_BASE . sprintf( \WpBitcoinNewsletter\Constants::SENDINBLUE_CONTACT, rawurlencode( strtolower( trim( $email ) ) ) );
         $payload = [ 'unlinkListIds' => [] ];
         $args    = [
             'method'  => 'PUT',

--- a/wp-bitcoin-newsletter/src/Providers/Newsletter/SendinblueProvider.php
+++ b/wp-bitcoin-newsletter/src/Providers/Newsletter/SendinblueProvider.php
@@ -6,7 +6,11 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
+/**
+ * Sendinblue/Brevo newsletter provider implementation.
+ */
 class SendinblueProvider implements NewsletterProviderInterface {
+    /** @inheritDoc */
     public function upsert( array $subscriber, array $options = [] ): bool {
         $apiKey = (string) ( $options['sendinblue_api_key'] ?? '' );
         $listId = (int) ( $options['sendinblue_list_id'] ?? 0 );
@@ -43,6 +47,7 @@ class SendinblueProvider implements NewsletterProviderInterface {
         return $code >= 200 && $code < 300;
     }
 
+    /** @inheritDoc */
     public function unsubscribe( string $email, array $options = [] ): bool {
         $apiKey = (string) ( $options['sendinblue_api_key'] ?? '' );
         if ( ! $apiKey ) {

--- a/wp-bitcoin-newsletter/src/Providers/Newsletter/SendinblueProvider.php
+++ b/wp-bitcoin-newsletter/src/Providers/Newsletter/SendinblueProvider.php
@@ -1,4 +1,10 @@
 <?php
+declare(strict_types=1);
+/**
+ * Sendinblue/Brevo provider.
+ *
+ * @package wp-bitcoin-newsletter
+ */
 
 namespace WpBitcoinNewsletter\Providers\Newsletter;
 

--- a/wp-bitcoin-newsletter/src/Providers/Payment/BTCPayProvider.php
+++ b/wp-bitcoin-newsletter/src/Providers/Payment/BTCPayProvider.php
@@ -1,10 +1,10 @@
 <?php
-declare(strict_types=1);
 /**
  * BTCPay provider.
  *
  * @package wp-bitcoin-newsletter
  */
+declare(strict_types=1);
 
 namespace WpBitcoinNewsletter\Providers\Payment;
 

--- a/wp-bitcoin-newsletter/src/Providers/Payment/BTCPayProvider.php
+++ b/wp-bitcoin-newsletter/src/Providers/Payment/BTCPayProvider.php
@@ -1,4 +1,10 @@
 <?php
+declare(strict_types=1);
+/**
+ * BTCPay provider.
+ *
+ * @package wp-bitcoin-newsletter
+ */
 
 namespace WpBitcoinNewsletter\Providers\Payment;
 

--- a/wp-bitcoin-newsletter/src/Providers/Payment/BTCPayProvider.php
+++ b/wp-bitcoin-newsletter/src/Providers/Payment/BTCPayProvider.php
@@ -3,6 +3,7 @@
 namespace WpBitcoinNewsletter\Providers\Payment;
 
 use WpBitcoinNewsletter\Admin\Settings;
+use WpBitcoinNewsletter\Constants;
 
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
@@ -21,7 +22,7 @@ class BTCPayProvider implements PaymentProviderInterface {
         if ( ! $host || ! $apiKey || ! $store ) {
             return [];
         }
-        $url     = $host . '/api/v1/stores/' . rawurlencode( $store ) . '/invoices';
+        $url     = $host . sprintf( Constants::BTCPAY_INVOICES_ENDPOINT, rawurlencode( $store ) );
         $payload = [
             'amount'   => (string) $amount,
             'currency' => $currency,

--- a/wp-bitcoin-newsletter/src/Providers/Payment/BTCPayProvider.php
+++ b/wp-bitcoin-newsletter/src/Providers/Payment/BTCPayProvider.php
@@ -4,73 +4,81 @@ namespace WpBitcoinNewsletter\Providers\Payment;
 
 use WpBitcoinNewsletter\Admin\Settings;
 
-class BTCPayProvider implements PaymentProviderInterface
-{
-    public function createInvoice(int $formId, int $amount, string $currency, array $subscriberData): array
-    {
-        $s = Settings::getSettings();
-        $host = rtrim((string)$s['btcpay_host'], '/');
-        $apiKey = (string)$s['btcpay_api_key'];
-        $store = (string)$s['btcpay_store_id'];
-        if (!$host || !$apiKey || !$store) return [];
-        $url = $host . '/api/v1/stores/' . rawurlencode($store) . '/invoices';
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class BTCPayProvider implements PaymentProviderInterface {
+    public function createInvoice( int $formId, int $amount, string $currency, array $subscriberData ): array {
+        $s      = Settings::getSettings();
+        $host   = rtrim( (string) $s['btcpay_host'], '/' );
+        $apiKey = (string) $s['btcpay_api_key'];
+        $store  = (string) $s['btcpay_store_id'];
+        if ( ! $host || ! $apiKey || ! $store ) {
+            return [];
+        }
+        $url     = $host . '/api/v1/stores/' . rawurlencode( $store ) . '/invoices';
         $payload = [
-            'amount' => (string)$amount,
+            'amount'   => (string) $amount,
             'currency' => $currency,
             'metadata' => [
                 'form_id' => $formId,
-                'email' => (string)$subscriberData['email'],
+                'email'   => (string) $subscriberData['email'],
             ],
         ];
-        $args = [
-            'method' => 'POST',
+        $args    = [
+            'method'  => 'POST',
             'headers' => [
                 'Authorization' => 'token ' . $apiKey,
-                'Content-Type' => 'application/json',
+                'Content-Type'  => 'application/json',
             ],
             'timeout' => 20,
-            'body' => wp_json_encode($payload),
+            'body'    => wp_json_encode( $payload ),
         ];
-        $args = apply_filters('wpbn_btcpay_request_args', $args, $formId);
-        $res = wp_remote_request($url, $args);
-        do_action('wpbn_btcpay_response', $res, $formId);
-        if (is_wp_error($res)) return [];
-        $code = wp_remote_retrieve_response_code($res);
-        $body = json_decode(wp_remote_retrieve_body($res), true);
-        if ($code >= 200 && $code < 300 && is_array($body)) {
-            $invoiceId = isset($body['id']) ? (string)$body['id'] : '';
-            $paymentUrl = isset($body['checkoutLink']) ? (string)$body['checkoutLink'] : '';
+        $args = apply_filters( 'wpbn_btcpay_request_args', $args, $formId );
+        $res  = wp_remote_request( $url, $args );
+        do_action( 'wpbn_btcpay_response', $res, $formId );
+        if ( is_wp_error( $res ) ) {
+            return [];
+        }
+        $code = wp_remote_retrieve_response_code( $res );
+        $body = json_decode( wp_remote_retrieve_body( $res ), true );
+        if ( $code >= 200 && $code < 300 && is_array( $body ) ) {
+            $invoiceId  = isset( $body['id'] ) ? (string) $body['id'] : '';
+            $paymentUrl = isset( $body['checkoutLink'] ) ? (string) $body['checkoutLink'] : '';
             return $invoiceId && $paymentUrl ? [
-                'invoice_id' => $invoiceId,
+                'invoice_id'  => $invoiceId,
                 'payment_url' => $paymentUrl,
             ] : [];
         }
         return [];
     }
 
-    public function handleWebhook(array $request): array
-    {
-        do_action('wpbn_btcpay_webhook_received', $request);
-        $invoiceId = isset($request['invoiceId']) ? (string)$request['invoiceId'] : '';
-        $type = isset($request['type']) ? (string)$request['type'] : '';
-        $paid = in_array($type, ['InvoiceSettled', 'PaymentReceived', 'InvoicePaid'], true);
+    public function handleWebhook( array $request ): array {
+        do_action( 'wpbn_btcpay_webhook_received', $request );
+        $invoiceId = isset( $request['invoiceId'] ) ? (string) $request['invoiceId'] : '';
+        $type      = isset( $request['type'] ) ? (string) $request['type'] : '';
+        $paid      = in_array( $type, [ 'InvoiceSettled', 'PaymentReceived', 'InvoicePaid' ], true );
         return [
             'invoice_id' => $invoiceId,
-            'paid' => $paid,
-            'metadata' => $request,
+            'paid'       => $paid,
+            'metadata'   => $request,
         ];
     }
 
-    public static function verifySignature(): bool
-    {
-        $s = Settings::getSettings();
-        $secret = (string)$s['btcpay_webhook_secret'];
-        if (!$secret) return false;
-        $sig = isset($_SERVER['HTTP_BTCPAY_SIGNATURE']) ? (string)$_SERVER['HTTP_BTCPAY_SIGNATURE'] : '';
-        $payload = file_get_contents('php://input') ?: '';
-        if (!$sig || !$payload) return false;
-        $calc = 'sha256=' . hash_hmac('sha256', $payload, $secret);
-        return hash_equals($calc, $sig);
+    public static function verifySignature(): bool {
+        $s       = Settings::getSettings();
+        $secret  = (string) $s['btcpay_webhook_secret'];
+        if ( ! $secret ) {
+            return false;
+        }
+        $sig     = isset( $_SERVER['HTTP_BTCPAY_SIGNATURE'] ) ? (string) $_SERVER['HTTP_BTCPAY_SIGNATURE'] : '';
+        $payload = file_get_contents( 'php://input' ) ?: '';
+        if ( ! $sig || ! $payload ) {
+            return false;
+        }
+        $calc = 'sha256=' . hash_hmac( 'sha256', $payload, $secret );
+        return hash_equals( $calc, $sig );
     }
 }
 

--- a/wp-bitcoin-newsletter/src/Providers/Payment/BTCPayProvider.php
+++ b/wp-bitcoin-newsletter/src/Providers/Payment/BTCPayProvider.php
@@ -8,7 +8,11 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
+/**
+ * BTCPay Server payment provider implementation.
+ */
 class BTCPayProvider implements PaymentProviderInterface {
+    /** @inheritDoc */
     public function create_invoice( int $formId, int $amount, string $currency, array $subscriberData ): array {
         $s      = Settings::getSettings();
         $host   = rtrim( (string) $s['btcpay_host'], '/' );
@@ -54,6 +58,7 @@ class BTCPayProvider implements PaymentProviderInterface {
         return [];
     }
 
+    /** @inheritDoc */
     public function handle_webhook( array $request ): array {
         do_action( 'wpbn_btcpay_webhook_received', $request );
         $invoiceId = isset( $request['invoiceId'] ) ? (string) $request['invoiceId'] : '';
@@ -66,6 +71,11 @@ class BTCPayProvider implements PaymentProviderInterface {
         ];
     }
 
+    /**
+     * Verify BTCPay webhook signature.
+     *
+     * @return bool True if valid.
+     */
     public static function verify_signature(): bool {
         $s       = Settings::getSettings();
         $secret  = (string) $s['btcpay_webhook_secret'];

--- a/wp-bitcoin-newsletter/src/Providers/Payment/BTCPayProvider.php
+++ b/wp-bitcoin-newsletter/src/Providers/Payment/BTCPayProvider.php
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class BTCPayProvider implements PaymentProviderInterface {
-    public function createInvoice( int $formId, int $amount, string $currency, array $subscriberData ): array {
+    public function create_invoice( int $formId, int $amount, string $currency, array $subscriberData ): array {
         $s      = Settings::getSettings();
         $host   = rtrim( (string) $s['btcpay_host'], '/' );
         $apiKey = (string) $s['btcpay_api_key'];
@@ -54,7 +54,7 @@ class BTCPayProvider implements PaymentProviderInterface {
         return [];
     }
 
-    public function handleWebhook( array $request ): array {
+    public function handle_webhook( array $request ): array {
         do_action( 'wpbn_btcpay_webhook_received', $request );
         $invoiceId = isset( $request['invoiceId'] ) ? (string) $request['invoiceId'] : '';
         $type      = isset( $request['type'] ) ? (string) $request['type'] : '';
@@ -66,7 +66,7 @@ class BTCPayProvider implements PaymentProviderInterface {
         ];
     }
 
-    public static function verifySignature(): bool {
+    public static function verify_signature(): bool {
         $s       = Settings::getSettings();
         $secret  = (string) $s['btcpay_webhook_secret'];
         if ( ! $secret ) {

--- a/wp-bitcoin-newsletter/src/Providers/Payment/CoinsnapProvider.php
+++ b/wp-bitcoin-newsletter/src/Providers/Payment/CoinsnapProvider.php
@@ -8,7 +8,11 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
+/**
+ * CoinSnap payment provider implementation.
+ */
 class CoinsnapProvider implements PaymentProviderInterface {
+    /** @inheritDoc */
     public function create_invoice( int $formId, int $amount, string $currency, array $subscriberData ): array {
         $settings = Settings::getSettings();
         $apiKey   = $settings['coinsnap_api_key'];
@@ -70,6 +74,7 @@ class CoinsnapProvider implements PaymentProviderInterface {
         return [];
     }
 
+    /** @inheritDoc */
     public function handle_webhook( array $request ): array {
         do_action( 'wpbn_coinsnap_webhook_received', $request );
         $invoiceId = isset( $request['invoiceId'] ) ? (string) $request['invoiceId'] : '';
@@ -82,6 +87,11 @@ class CoinsnapProvider implements PaymentProviderInterface {
         ];
     }
 
+    /**
+     * Verify webhook HMAC signature.
+     *
+     * @return bool True if signature valid.
+     */
     public static function verify_signature(): bool {
         $settings = Settings::getSettings();
         $secret   = (string) $settings['coinsnap_webhook_secret'];

--- a/wp-bitcoin-newsletter/src/Providers/Payment/CoinsnapProvider.php
+++ b/wp-bitcoin-newsletter/src/Providers/Payment/CoinsnapProvider.php
@@ -37,8 +37,11 @@ class CoinsnapProvider implements PaymentProviderInterface {
         $args    = [
             'method'  => 'POST',
             'headers' => [
-                'Authorization' => 'token ' . $apiKey,
-                'Content-Type'  => 'application/json',
+                // New API header per latest docs; keep Authorization for backward compatibility.
+                'X-Api-Key'    => $apiKey,
+                'Authorization'=> 'token ' . $apiKey,
+                'Content-Type' => 'application/json',
+                'accept'       => 'application/json',
             ],
             'timeout' => 20,
             'body'    => wp_json_encode( $payload ),

--- a/wp-bitcoin-newsletter/src/Providers/Payment/CoinsnapProvider.php
+++ b/wp-bitcoin-newsletter/src/Providers/Payment/CoinsnapProvider.php
@@ -1,10 +1,10 @@
 <?php
-declare(strict_types=1);
 /**
  * Coinsnap provider.
  *
  * @package wp-bitcoin-newsletter
  */
+declare(strict_types=1);
 
 namespace WpBitcoinNewsletter\Providers\Payment;
 

--- a/wp-bitcoin-newsletter/src/Providers/Payment/CoinsnapProvider.php
+++ b/wp-bitcoin-newsletter/src/Providers/Payment/CoinsnapProvider.php
@@ -3,6 +3,7 @@
 namespace WpBitcoinNewsletter\Providers\Payment;
 
 use WpBitcoinNewsletter\Admin\Settings;
+use WpBitcoinNewsletter\Constants;
 
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
@@ -17,13 +18,13 @@ class CoinsnapProvider implements PaymentProviderInterface {
         $settings = Settings::getSettings();
         $apiKey   = $settings['coinsnap_api_key'];
         $storeId  = $settings['coinsnap_store_id'];
-        $apiBase  = rtrim( $settings['coinsnap_api_base'], '/' );
+        $apiBase  = rtrim( $settings['coinsnap_api_base'] ?: Constants::COINSNAP_DEFAULT_API_BASE, '/' );
         if ( ! $apiKey || ! $storeId ) {
             return [];
         }
         $endpoints = [
-            $apiBase . '/api/v1/stores/' . rawurlencode( $storeId ) . '/invoices',
-            $apiBase . '/api/stores/' . rawurlencode( $storeId ) . '/invoices',
+            $apiBase . sprintf( Constants::COINSNAP_INVOICES_ENDPOINT_V1, rawurlencode( $storeId ) ),
+            $apiBase . sprintf( Constants::COINSNAP_INVOICES_ENDPOINT_ALT, rawurlencode( $storeId ) ),
         ];
         $payload   = [
             'amount'    => (string) $amount,

--- a/wp-bitcoin-newsletter/src/Providers/Payment/CoinsnapProvider.php
+++ b/wp-bitcoin-newsletter/src/Providers/Payment/CoinsnapProvider.php
@@ -1,4 +1,10 @@
 <?php
+declare(strict_types=1);
+/**
+ * Coinsnap provider.
+ *
+ * @package wp-bitcoin-newsletter
+ */
 
 namespace WpBitcoinNewsletter\Providers\Payment;
 

--- a/wp-bitcoin-newsletter/src/Providers/Payment/CoinsnapProvider.php
+++ b/wp-bitcoin-newsletter/src/Providers/Payment/CoinsnapProvider.php
@@ -4,57 +4,61 @@ namespace WpBitcoinNewsletter\Providers\Payment;
 
 use WpBitcoinNewsletter\Admin\Settings;
 
-class CoinsnapProvider implements PaymentProviderInterface
-{
-    public function createInvoice(int $formId, int $amount, string $currency, array $subscriberData): array
-    {
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class CoinsnapProvider implements PaymentProviderInterface {
+    public function createInvoice( int $formId, int $amount, string $currency, array $subscriberData ): array {
         $settings = Settings::getSettings();
-        $apiKey = $settings['coinsnap_api_key'];
-        $storeId = $settings['coinsnap_store_id'];
-        $apiBase = rtrim($settings['coinsnap_api_base'], '/');
-        if (!$apiKey || !$storeId) {
+        $apiKey   = $settings['coinsnap_api_key'];
+        $storeId  = $settings['coinsnap_store_id'];
+        $apiBase  = rtrim( $settings['coinsnap_api_base'], '/' );
+        if ( ! $apiKey || ! $storeId ) {
             return [];
         }
         $endpoints = [
-            $apiBase . '/api/v1/stores/' . rawurlencode($storeId) . '/invoices',
-            $apiBase . '/api/stores/' . rawurlencode($storeId) . '/invoices',
+            $apiBase . '/api/v1/stores/' . rawurlencode( $storeId ) . '/invoices',
+            $apiBase . '/api/stores/' . rawurlencode( $storeId ) . '/invoices',
         ];
-        $payload = [
-            'amount' => (string)$amount,
-            'currency' => $currency,
-            'buyerEmail' => isset($subscriberData['email']) ? (string)$subscriberData['email'] : '',
-            'metadata' => [
+        $payload   = [
+            'amount'    => (string) $amount,
+            'currency'  => $currency,
+            'buyerEmail'=> isset( $subscriberData['email'] ) ? (string) $subscriberData['email'] : '',
+            'metadata'  => [
                 'form_id' => $formId,
-                'email' => (string)($subscriberData['email'] ?? ''),
+                'email'   => (string) ( $subscriberData['email'] ?? '' ),
             ],
-            'checkout' => [
+            'checkout'  => [
                 'defaultPaymentMethod' => 'LightningNetwork',
             ],
         ];
-        $payload = apply_filters('wpbn_coinsnap_invoice_payload', $payload, $formId, $subscriberData);
-        $args = [
-            'method' => 'POST',
+        $payload = apply_filters( 'wpbn_coinsnap_invoice_payload', $payload, $formId, $subscriberData );
+        $args    = [
+            'method'  => 'POST',
             'headers' => [
                 'Authorization' => 'token ' . $apiKey,
-                'Content-Type' => 'application/json',
+                'Content-Type'  => 'application/json',
             ],
             'timeout' => 20,
-            'body' => wp_json_encode($payload),
+            'body'    => wp_json_encode( $payload ),
         ];
-        $args = apply_filters('wpbn_coinsnap_request_args', $args, $formId);
-        foreach ($endpoints as $url) {
-            $res = wp_remote_request($url, $args);
+        $args = apply_filters( 'wpbn_coinsnap_request_args', $args, $formId );
+        foreach ( $endpoints as $url ) {
+            $res = wp_remote_request( $url, $args );
             /** Action: on Coinsnap response (raw) */
-            do_action('wpbn_coinsnap_response', $res, $formId);
-            if (is_wp_error($res)) continue;
-            $code = wp_remote_retrieve_response_code($res);
-            $body = json_decode(wp_remote_retrieve_body($res), true);
-            if ($code >= 200 && $code < 300 && is_array($body)) {
-                $invoiceId = isset($body['id']) ? (string)$body['id'] : '';
-                $paymentUrl = isset($body['checkoutLink']) ? (string)$body['checkoutLink'] : '';
-                if ($invoiceId && $paymentUrl) {
+            do_action( 'wpbn_coinsnap_response', $res, $formId );
+            if ( is_wp_error( $res ) ) {
+                continue;
+            }
+            $code = wp_remote_retrieve_response_code( $res );
+            $body = json_decode( wp_remote_retrieve_body( $res ), true );
+            if ( $code >= 200 && $code < 300 && is_array( $body ) ) {
+                $invoiceId  = isset( $body['id'] ) ? (string) $body['id'] : '';
+                $paymentUrl = isset( $body['checkoutLink'] ) ? (string) $body['checkoutLink'] : '';
+                if ( $invoiceId && $paymentUrl ) {
                     return [
-                        'invoice_id' => $invoiceId,
+                        'invoice_id'  => $invoiceId,
                         'payment_url' => $paymentUrl,
                     ];
                 }
@@ -63,36 +67,40 @@ class CoinsnapProvider implements PaymentProviderInterface
         return [];
     }
 
-    public function handleWebhook(array $request): array
-    {
-        do_action('wpbn_coinsnap_webhook_received', $request);
-        $invoiceId = isset($request['invoiceId']) ? (string)$request['invoiceId'] : '';
-        $type = isset($request['type']) ? (string)$request['type'] : '';
-        $paid = in_array($type, ['InvoiceSettled', 'PaymentReceived', 'InvoicePaid'], true);
+    public function handleWebhook( array $request ): array {
+        do_action( 'wpbn_coinsnap_webhook_received', $request );
+        $invoiceId = isset( $request['invoiceId'] ) ? (string) $request['invoiceId'] : '';
+        $type      = isset( $request['type'] ) ? (string) $request['type'] : '';
+        $paid      = in_array( $type, [ 'InvoiceSettled', 'PaymentReceived', 'InvoicePaid' ], true );
         return [
             'invoice_id' => $invoiceId,
-            'paid' => $paid,
-            'metadata' => $request,
+            'paid'       => $paid,
+            'metadata'   => $request,
         ];
     }
 
-    public static function verifySignature(): bool
-    {
+    public static function verifySignature(): bool {
         $settings = Settings::getSettings();
-        $secret = (string)$settings['coinsnap_webhook_secret'];
-        if (!$secret) return false;
+        $secret   = (string) $settings['coinsnap_webhook_secret'];
+        if ( ! $secret ) {
+            return false;
+        }
         $headers = [
-            isset($_SERVER['HTTP_BTCPAY_SIGNATURE']) ? (string)$_SERVER['HTTP_BTCPAY_SIGNATURE'] : '',
-            isset($_SERVER['HTTP_X_COINSNAP_SIGNATURE']) ? (string)$_SERVER['HTTP_X_COINSNAP_SIGNATURE'] : '',
-            isset($_SERVER['HTTP_X_SIGNATURE']) ? (string)$_SERVER['HTTP_X_SIGNATURE'] : '',
+            isset( $_SERVER['HTTP_BTCPAY_SIGNATURE'] ) ? (string) $_SERVER['HTTP_BTCPAY_SIGNATURE'] : '',
+            isset( $_SERVER['HTTP_X_COINSNAP_SIGNATURE'] ) ? (string) $_SERVER['HTTP_X_COINSNAP_SIGNATURE'] : '',
+            isset( $_SERVER['HTTP_X_SIGNATURE'] ) ? (string) $_SERVER['HTTP_X_SIGNATURE'] : '',
         ];
-        $payload = file_get_contents('php://input') ?: '';
-        if (!$payload) return false;
-        $raw = hash_hmac('sha256', $payload, $secret);
+        $payload = file_get_contents( 'php://input' ) ?: '';
+        if ( ! $payload ) {
+            return false;
+        }
+        $raw        = hash_hmac( 'sha256', $payload, $secret );
         $withPrefix = 'sha256=' . $raw;
-        foreach ($headers as $sig) {
-            if (!$sig) continue;
-            if (hash_equals($raw, $sig) || hash_equals($withPrefix, $sig)) {
+        foreach ( $headers as $sig ) {
+            if ( ! $sig ) {
+                continue;
+            }
+            if ( hash_equals( $raw, $sig ) || hash_equals( $withPrefix, $sig ) ) {
                 return true;
             }
         }

--- a/wp-bitcoin-newsletter/src/Providers/Payment/CoinsnapProvider.php
+++ b/wp-bitcoin-newsletter/src/Providers/Payment/CoinsnapProvider.php
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class CoinsnapProvider implements PaymentProviderInterface {
-    public function createInvoice( int $formId, int $amount, string $currency, array $subscriberData ): array {
+    public function create_invoice( int $formId, int $amount, string $currency, array $subscriberData ): array {
         $settings = Settings::getSettings();
         $apiKey   = $settings['coinsnap_api_key'];
         $storeId  = $settings['coinsnap_store_id'];
@@ -67,7 +67,7 @@ class CoinsnapProvider implements PaymentProviderInterface {
         return [];
     }
 
-    public function handleWebhook( array $request ): array {
+    public function handle_webhook( array $request ): array {
         do_action( 'wpbn_coinsnap_webhook_received', $request );
         $invoiceId = isset( $request['invoiceId'] ) ? (string) $request['invoiceId'] : '';
         $type      = isset( $request['type'] ) ? (string) $request['type'] : '';
@@ -79,7 +79,7 @@ class CoinsnapProvider implements PaymentProviderInterface {
         ];
     }
 
-    public static function verifySignature(): bool {
+    public static function verify_signature(): bool {
         $settings = Settings::getSettings();
         $secret   = (string) $settings['coinsnap_webhook_secret'];
         if ( ! $secret ) {

--- a/wp-bitcoin-newsletter/src/Providers/Payment/PaymentProviderInterface.php
+++ b/wp-bitcoin-newsletter/src/Providers/Payment/PaymentProviderInterface.php
@@ -2,17 +2,24 @@
 
 namespace WpBitcoinNewsletter\Providers\Payment;
 
-interface PaymentProviderInterface
-{
+interface PaymentProviderInterface {
     /**
-     * Create a payment invoice and return an array containing keys:
-     * - invoice_id (string)
-     * - payment_url (string)
-     * - expires_at (int timestamp) optional
+     * Create a payment invoice.
+     *
+     * @param int    $formId         Form ID.
+     * @param int    $amount         Amount.
+     * @param string $currency       Currency code.
+     * @param array  $subscriberData Subscriber data.
+     * @return array { invoice_id: string, payment_url: string, expires_at?: int }
      */
-    public function createInvoice(int $formId, int $amount, string $currency, array $subscriberData): array;
+    public function createInvoice( int $formId, int $amount, string $currency, array $subscriberData ): array;
 
-    /** Validate webhook or callback and return ['invoice_id' => string, 'paid' => bool, 'metadata' => array] */
-    public function handleWebhook(array $request): array;
+    /**
+     * Validate webhook or callback.
+     *
+     * @param array $request Parsed request body.
+     * @return array { invoice_id: string, paid: bool, metadata: array }
+     */
+    public function handleWebhook( array $request ): array;
 }
 

--- a/wp-bitcoin-newsletter/src/Providers/Payment/PaymentProviderInterface.php
+++ b/wp-bitcoin-newsletter/src/Providers/Payment/PaymentProviderInterface.php
@@ -1,4 +1,10 @@
 <?php
+declare(strict_types=1);
+/**
+ * Payment provider interface.
+ *
+ * @package wp-bitcoin-newsletter
+ */
 
 namespace WpBitcoinNewsletter\Providers\Payment;
 

--- a/wp-bitcoin-newsletter/src/Providers/Payment/PaymentProviderInterface.php
+++ b/wp-bitcoin-newsletter/src/Providers/Payment/PaymentProviderInterface.php
@@ -12,7 +12,7 @@ interface PaymentProviderInterface {
      * @param array  $subscriberData Subscriber data.
      * @return array { invoice_id: string, payment_url: string, expires_at?: int }
      */
-    public function createInvoice( int $formId, int $amount, string $currency, array $subscriberData ): array;
+    public function create_invoice( int $formId, int $amount, string $currency, array $subscriberData ): array;
 
     /**
      * Validate webhook or callback.
@@ -20,6 +20,6 @@ interface PaymentProviderInterface {
      * @param array $request Parsed request body.
      * @return array { invoice_id: string, paid: bool, metadata: array }
      */
-    public function handleWebhook( array $request ): array;
+    public function handle_webhook( array $request ): array;
 }
 

--- a/wp-bitcoin-newsletter/src/Providers/Payment/PaymentProviderInterface.php
+++ b/wp-bitcoin-newsletter/src/Providers/Payment/PaymentProviderInterface.php
@@ -1,10 +1,10 @@
 <?php
-declare(strict_types=1);
 /**
  * Payment provider interface.
  *
  * @package wp-bitcoin-newsletter
  */
+declare(strict_types=1);
 
 namespace WpBitcoinNewsletter\Providers\Payment;
 

--- a/wp-bitcoin-newsletter/src/Providers/Payment/PaymentProviderInterface.php
+++ b/wp-bitcoin-newsletter/src/Providers/Payment/PaymentProviderInterface.php
@@ -2,7 +2,19 @@
 
 namespace WpBitcoinNewsletter\Providers\Payment;
 
+/**
+ * Payment providers must implement invoice creation and webhook handling.
+ */
 interface PaymentProviderInterface {
+    /**
+     * Create a payment invoice.
+     *
+     * @param int    $formId         Form ID.
+     * @param int    $amount         Amount.
+     * @param string $currency       Currency code.
+     * @param array  $subscriberData Subscriber data.
+     * @return array { invoice_id: string, payment_url: string, expires_at?: int }
+     */
     /**
      * Create a payment invoice.
      *
@@ -14,6 +26,12 @@ interface PaymentProviderInterface {
      */
     public function create_invoice( int $formId, int $amount, string $currency, array $subscriberData ): array;
 
+    /**
+     * Validate webhook or callback.
+     *
+     * @param array $request Parsed request body.
+     * @return array { invoice_id: string, paid: bool, metadata: array }
+     */
     /**
      * Validate webhook or callback.
      *

--- a/wp-bitcoin-newsletter/src/Rest/Routes.php
+++ b/wp-bitcoin-newsletter/src/Rest/Routes.php
@@ -11,7 +11,11 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
+/**
+ * REST API routes and callbacks.
+ */
 class Routes {
+    /** Register routes under wpbn/v1. */
     public static function register(): void {
         register_rest_route(
             'wpbn/v1',
@@ -64,6 +68,12 @@ class Routes {
         );
     }
 
+    /**
+     * Coinsnap webhook endpoint.
+     *
+     * @param \WP_REST_Request $request Request.
+     * @return \WP_Error|\WP_REST_Response
+     */
     public static function coinsnap_webhook( $request ) {
         if ( ! CoinsnapProvider::verify_signature() ) {
             return new \WP_Error( 'invalid_signature', 'Invalid signature', [ 'status' => 401 ] );
@@ -77,6 +87,12 @@ class Routes {
         return new \WP_Error( 'invalid', 'Invalid webhook', [ 'status' => 400 ] );
     }
 
+    /**
+     * BTCPay webhook endpoint.
+     *
+     * @param \WP_REST_Request $request Request.
+     * @return \WP_Error|\WP_REST_Response
+     */
     public static function btcpay_webhook( $request ) {
         if ( ! BTCPayProvider::verify_signature() ) {
             return new \WP_Error( 'invalid_signature', 'Invalid signature', [ 'status' => 401 ] );
@@ -90,6 +106,12 @@ class Routes {
         return new \WP_Error( 'invalid', 'Invalid webhook', [ 'status' => 400 ] );
     }
 
+    /**
+     * Check invoice status.
+     *
+     * @param \WP_REST_Request $request Request.
+     * @return \WP_REST_Response
+     */
     public static function status( $request ) {
         $invoice = sanitize_text_field( (string) $request['invoice'] );
         global $wpdb;
@@ -109,12 +131,24 @@ class Routes {
         );
     }
 
+    /**
+     * Resync a single subscriber.
+     *
+     * @param \WP_REST_Request $request Request.
+     * @return \WP_REST_Response
+     */
     public static function resync( $request ) {
         $id = (int) $request['id'];
         $ok = SyncService::resync( $id );
         return rest_ensure_response( [ 'ok' => (bool) $ok ] );
     }
 
+    /**
+     * Resync multiple subscribers.
+     *
+     * @param \WP_REST_Request $request Request.
+     * @return \WP_REST_Response
+     */
     public static function bulk_resync( $request ) {
         $ids = (array) $request->get_param( 'ids' );
         $ids = array_map( 'absint', $ids );

--- a/wp-bitcoin-newsletter/src/Rest/Routes.php
+++ b/wp-bitcoin-newsletter/src/Rest/Routes.php
@@ -3,6 +3,7 @@
 namespace WpBitcoinNewsletter\Rest;
 
 use WpBitcoinNewsletter\Services\SyncService;
+use WpBitcoinNewsletter\Constants;
 use WpBitcoinNewsletter\Providers\Payment\CoinsnapProvider;
 use WpBitcoinNewsletter\Providers\Payment\BTCPayProvider;
 use WpBitcoinNewsletter\Database\Installer;
@@ -18,8 +19,8 @@ class Routes {
     /** Register routes under wpbn/v1. */
     public static function register(): void {
         register_rest_route(
-            'wpbn/v1',
-            '/payment/coinsnap',
+            Constants::REST_NAMESPACE,
+            Constants::REST_ROUTE_PAYMENT_COINSNAP,
             [
                 'methods'             => 'POST',
                 'permission_callback' => '__return_true',
@@ -28,8 +29,8 @@ class Routes {
         );
 
         register_rest_route(
-            'wpbn/v1',
-            '/payment/btcpay',
+            Constants::REST_NAMESPACE,
+            Constants::REST_ROUTE_PAYMENT_BTCPAY,
             [
                 'methods'             => 'POST',
                 'permission_callback' => '__return_true',
@@ -38,8 +39,8 @@ class Routes {
         );
 
         register_rest_route(
-            'wpbn/v1',
-            '/status/(?P<invoice>[^/]+)',
+            Constants::REST_NAMESPACE,
+            Constants::REST_ROUTE_STATUS,
             [
                 'methods'             => 'GET',
                 'permission_callback' => '__return_true',
@@ -48,8 +49,8 @@ class Routes {
         );
 
         register_rest_route(
-            'wpbn/v1',
-            '/subscribers/(?P<id>\\d+)/resync',
+            Constants::REST_NAMESPACE,
+            Constants::REST_ROUTE_RESYNC,
             [
                 'methods'             => 'POST',
                 'permission_callback' => function () { return current_user_can( 'manage_options' ); },
@@ -58,8 +59,8 @@ class Routes {
         );
 
         register_rest_route(
-            'wpbn/v1',
-            '/subscribers/bulk-resync',
+            Constants::REST_NAMESPACE,
+            Constants::REST_ROUTE_BULK_RESYNC,
             [
                 'methods'             => 'POST',
                 'permission_callback' => function () { return current_user_can( 'manage_options' ); },

--- a/wp-bitcoin-newsletter/src/Rest/Routes.php
+++ b/wp-bitcoin-newsletter/src/Rest/Routes.php
@@ -7,103 +7,122 @@ use WpBitcoinNewsletter\Providers\Payment\CoinsnapProvider;
 use WpBitcoinNewsletter\Providers\Payment\BTCPayProvider;
 use WpBitcoinNewsletter\Database\Installer;
 
-defined('ABSPATH') || exit;
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
 
-class Routes
-{
-    public static function register(): void
-    {
-        register_rest_route('wpbn/v1', '/payment/coinsnap', [
-            'methods' => 'POST',
-            'permission_callback' => '__return_true',
-            'callback' => [__CLASS__, 'coinsnapWebhook'],
-        ]);
+class Routes {
+    public static function register(): void {
+        register_rest_route(
+            'wpbn/v1',
+            '/payment/coinsnap',
+            [
+                'methods'             => 'POST',
+                'permission_callback' => '__return_true',
+                'callback'            => [ __CLASS__, 'coinsnapWebhook' ],
+            ]
+        );
 
-        register_rest_route('wpbn/v1', '/payment/btcpay', [
-            'methods' => 'POST',
-            'permission_callback' => '__return_true',
-            'callback' => [__CLASS__, 'btcpayWebhook'],
-        ]);
+        register_rest_route(
+            'wpbn/v1',
+            '/payment/btcpay',
+            [
+                'methods'             => 'POST',
+                'permission_callback' => '__return_true',
+                'callback'            => [ __CLASS__, 'btcpayWebhook' ],
+            ]
+        );
 
-        register_rest_route('wpbn/v1', '/status/(?P<invoice>[^/]+)', [
-            'methods' => 'GET',
-            'permission_callback' => '__return_true',
-            'callback' => [__CLASS__, 'status'],
-        ]);
+        register_rest_route(
+            'wpbn/v1',
+            '/status/(?P<invoice>[^/]+)',
+            [
+                'methods'             => 'GET',
+                'permission_callback' => '__return_true',
+                'callback'            => [ __CLASS__, 'status' ],
+            ]
+        );
 
-        register_rest_route('wpbn/v1', '/subscribers/(?P<id>\\d+)/resync', [
-            'methods' => 'POST',
-            'permission_callback' => function(){ return current_user_can('manage_options'); },
-            'callback' => [__CLASS__, 'resync'],
-        ]);
+        register_rest_route(
+            'wpbn/v1',
+            '/subscribers/(?P<id>\\d+)/resync',
+            [
+                'methods'             => 'POST',
+                'permission_callback' => function () { return current_user_can( 'manage_options' ); },
+                'callback'            => [ __CLASS__, 'resync' ],
+            ]
+        );
 
-        register_rest_route('wpbn/v1', '/subscribers/bulk-resync', [
-            'methods' => 'POST',
-            'permission_callback' => function(){ return current_user_can('manage_options'); },
-            'callback' => [__CLASS__, 'bulkResync'],
-        ]);
+        register_rest_route(
+            'wpbn/v1',
+            '/subscribers/bulk-resync',
+            [
+                'methods'             => 'POST',
+                'permission_callback' => function () { return current_user_can( 'manage_options' ); },
+                'callback'            => [ __CLASS__, 'bulkResync' ],
+            ]
+        );
     }
 
-    public static function coinsnapWebhook($request)
-    {
-        if (!CoinsnapProvider::verifySignature()) {
-            return new \WP_Error('invalid_signature', 'Invalid signature', ['status' => 401]);
+    public static function coinsnapWebhook( $request ) {
+        if ( ! CoinsnapProvider::verifySignature() ) {
+            return new \WP_Error( 'invalid_signature', 'Invalid signature', [ 'status' => 401 ] );
         }
-        $params = json_decode($request->get_body(), true) ?: [];
-        $parsed = (new CoinsnapProvider())->handleWebhook($params);
-        if (!empty($parsed['invoice_id']) && !empty($parsed['paid'])) {
-            $res = SyncService::handlePaymentPaid((string)$parsed['invoice_id'], $params);
-            return rest_ensure_response(['ok' => $res['ok']]);
+        $params = json_decode( $request->get_body(), true ) ?: [];
+        $parsed = ( new CoinsnapProvider() )->handleWebhook( $params );
+        if ( ! empty( $parsed['invoice_id'] ) && ! empty( $parsed['paid'] ) ) {
+            $res = SyncService::handlePaymentPaid( (string) $parsed['invoice_id'], $params );
+            return rest_ensure_response( [ 'ok' => $res['ok'] ] );
         }
-        return new \WP_Error('invalid', 'Invalid webhook', ['status' => 400]);
+        return new \WP_Error( 'invalid', 'Invalid webhook', [ 'status' => 400 ] );
     }
 
-    public static function btcpayWebhook($request)
-    {
-        if (!BTCPayProvider::verifySignature()) {
-            return new \WP_Error('invalid_signature', 'Invalid signature', ['status' => 401]);
+    public static function btcpayWebhook( $request ) {
+        if ( ! BTCPayProvider::verifySignature() ) {
+            return new \WP_Error( 'invalid_signature', 'Invalid signature', [ 'status' => 401 ] );
         }
-        $params = json_decode($request->get_body(), true) ?: [];
-        $parsed = (new BTCPayProvider())->handleWebhook($params);
-        if (!empty($parsed['invoice_id']) && !empty($parsed['paid'])) {
-            $res = SyncService::handlePaymentPaid((string)$parsed['invoice_id'], $params);
-            return rest_ensure_response(['ok' => $res['ok']]);
+        $params = json_decode( $request->get_body(), true ) ?: [];
+        $parsed = ( new BTCPayProvider() )->handleWebhook( $params );
+        if ( ! empty( $parsed['invoice_id'] ) && ! empty( $parsed['paid'] ) ) {
+            $res = SyncService::handlePaymentPaid( (string) $parsed['invoice_id'], $params );
+            return rest_ensure_response( [ 'ok' => $res['ok'] ] );
         }
-        return new \WP_Error('invalid', 'Invalid webhook', ['status' => 400]);
+        return new \WP_Error( 'invalid', 'Invalid webhook', [ 'status' => 400 ] );
     }
 
-    public static function status($request)
-    {
-        $invoice = sanitize_text_field((string)$request['invoice']);
+    public static function status( $request ) {
+        $invoice = sanitize_text_field( (string) $request['invoice'] );
         global $wpdb;
-        $table = Installer::tableName($wpdb);
-        $row = $wpdb->get_row($wpdb->prepare("SELECT payment_status, form_id FROM {$table} WHERE payment_invoice_id=%s", $invoice), ARRAY_A);
-        if (!$row) return rest_ensure_response(['exists' => false]);
-        $welcome = get_post_meta((int)$row['form_id'], '_wpbn_email', true);
-        $welcomeUrl = is_array($welcome) && !empty($welcome['welcome_url']) ? esc_url_raw($welcome['welcome_url']) : home_url('/');
-        return rest_ensure_response([
-            'exists' => true,
-            'paid' => $row['payment_status'] === 'paid',
-            'redirect' => $row['payment_status'] === 'paid' ? $welcomeUrl : '',
-        ]);
-    }
-
-    public static function resync($request)
-    {
-        $id = (int)$request['id'];
-        $ok = SyncService::resync($id);
-        return rest_ensure_response(['ok' => (bool)$ok]);
-    }
-
-    public static function bulkResync($request)
-    {
-        $ids = (array)$request->get_param('ids');
-        $ids = array_map('absint', $ids);
-        $ok = true;
-        foreach ($ids as $id) {
-            $ok = SyncService::resync((int)$id) && $ok;
+        $table = Installer::tableName( $wpdb );
+        $row   = $wpdb->get_row( $wpdb->prepare( "SELECT payment_status, form_id FROM {$table} WHERE payment_invoice_id=%s", $invoice ), ARRAY_A );
+        if ( ! $row ) {
+            return rest_ensure_response( [ 'exists' => false ] );
         }
-        return rest_ensure_response(['ok' => $ok]);
+        $welcome    = get_post_meta( (int) $row['form_id'], '_wpbn_email', true );
+        $welcomeUrl = is_array( $welcome ) && ! empty( $welcome['welcome_url'] ) ? esc_url_raw( $welcome['welcome_url'] ) : home_url( '/' );
+        return rest_ensure_response(
+            [
+                'exists'   => true,
+                'paid'     => $row['payment_status'] === 'paid',
+                'redirect' => $row['payment_status'] === 'paid' ? $welcomeUrl : '',
+            ]
+        );
+    }
+
+    public static function resync( $request ) {
+        $id = (int) $request['id'];
+        $ok = SyncService::resync( $id );
+        return rest_ensure_response( [ 'ok' => (bool) $ok ] );
+    }
+
+    public static function bulkResync( $request ) {
+        $ids = (array) $request->get_param( 'ids' );
+        $ids = array_map( 'absint', $ids );
+        $ok  = true;
+        foreach ( $ids as $id ) {
+            $ok = SyncService::resync( (int) $id ) && $ok;
+        }
+        return rest_ensure_response( [ 'ok' => $ok ] );
     }
 }
 

--- a/wp-bitcoin-newsletter/src/Rest/Routes.php
+++ b/wp-bitcoin-newsletter/src/Rest/Routes.php
@@ -1,10 +1,10 @@
 <?php
-declare(strict_types=1);
 /**
  * REST routes.
  *
  * @package wp-bitcoin-newsletter
  */
+declare(strict_types=1);
 
 namespace WpBitcoinNewsletter\Rest;
 

--- a/wp-bitcoin-newsletter/src/Rest/Routes.php
+++ b/wp-bitcoin-newsletter/src/Rest/Routes.php
@@ -1,4 +1,10 @@
 <?php
+declare(strict_types=1);
+/**
+ * REST routes.
+ *
+ * @package wp-bitcoin-newsletter
+ */
 
 namespace WpBitcoinNewsletter\Rest;
 

--- a/wp-bitcoin-newsletter/src/Services/SyncService.php
+++ b/wp-bitcoin-newsletter/src/Services/SyncService.php
@@ -6,111 +6,126 @@ use WpBitcoinNewsletter\Database\Installer;
 use WpBitcoinNewsletter\Util\ProviderFactory;
 use WpBitcoinNewsletter\Admin\Settings;
 
-defined('ABSPATH') || exit;
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
 
-class SyncService
-{
-    public static function handlePaymentPaid(string $invoiceId, array $metadata = []): array
-    {
+class SyncService {
+    public static function handlePaymentPaid( string $invoiceId, array $metadata = [] ): array {
         global $wpdb;
-        $table = Installer::tableName($wpdb);
-        $subscriber = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$table} WHERE payment_invoice_id = %s LIMIT 1", $invoiceId), ARRAY_A);
-        if (!$subscriber) {
-            return ['ok' => false, 'message' => 'Invoice not found'];
+        $table      = Installer::tableName( $wpdb );
+        $subscriber = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE payment_invoice_id = %s LIMIT 1", $invoiceId ), ARRAY_A );
+        if ( ! $subscriber ) {
+            return [ 'ok' => false, 'message' => 'Invoice not found' ];
         }
-        if ($subscriber['payment_status'] === 'paid') {
-            // Already paid; still ensure provider sync
-            self::resync((int)$subscriber['id']);
-            return ['ok' => true, 'message' => 'Already paid'];
+        if ( $subscriber['payment_status'] === 'paid' ) {
+            // Already paid; still ensure provider sync.
+            self::resync( (int) $subscriber['id'] );
+            return [ 'ok' => true, 'message' => 'Already paid' ];
         }
 
-        $wpdb->update($table, [
-            'payment_status' => 'paid',
-            'updated_at' => current_time('mysql'),
-        ], [
-            'id' => (int)$subscriber['id'],
-        ], ['%s', '%s'], ['%d']);
+        $wpdb->update(
+            $table,
+            [
+                'payment_status' => 'paid',
+                'updated_at'     => current_time( 'mysql' ),
+            ],
+            [
+                'id' => (int) $subscriber['id'],
+            ],
+            [ '%s', '%s' ],
+            [ '%d' ]
+        );
 
-        do_action('wpbn_payment_marked_paid', $invoiceId, $subscriber);
+        do_action( 'wpbn_payment_marked_paid', $invoiceId, $subscriber );
 
-        self::resync((int)$subscriber['id']);
+        self::resync( (int) $subscriber['id'] );
 
-        $welcome = get_post_meta((int)$subscriber['form_id'], '_wpbn_email', true);
-        $welcomeUrl = is_array($welcome) && !empty($welcome['welcome_url']) ? esc_url_raw($welcome['welcome_url']) : home_url('/');
+        $welcome    = get_post_meta( (int) $subscriber['form_id'], '_wpbn_email', true );
+        $welcomeUrl = is_array( $welcome ) && ! empty( $welcome['welcome_url'] ) ? esc_url_raw( $welcome['welcome_url'] ) : home_url( '/' );
 
-        return ['ok' => true, 'redirect' => $welcomeUrl];
+        return [ 'ok' => true, 'redirect' => $welcomeUrl ];
     }
 
-    public static function resync(int $subscriberId): bool
-    {
+    public static function resync( int $subscriberId ): bool {
         global $wpdb;
-        $table = Installer::tableName($wpdb);
-        $subscriber = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$table} WHERE id = %d", $subscriberId), ARRAY_A);
-        if (!$subscriber) return false;
-        $formId = (int)$subscriber['form_id'];
+        $table      = Installer::tableName( $wpdb );
+        $subscriber = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d", $subscriberId ), ARRAY_A );
+        if ( ! $subscriber ) {
+            return false;
+        }
+        $formId = (int) $subscriber['form_id'];
 
-        $provider = ProviderFactory::newsletter($formId);
-        $settings = Settings::getSettings();
-        $emailMeta = get_post_meta($formId, '_wpbn_email', true);
-        $providerMeta = get_post_meta($formId, '_wpbn_provider', true);
-        $options = [
-            'double_opt_in' => is_array($emailMeta) && !empty($emailMeta['double_opt_in']),
-            'mailpoet_list_id' => isset($providerMeta['mailpoet_list_id']) && $providerMeta['mailpoet_list_id'] !== '' ? (int)$providerMeta['mailpoet_list_id'] : (int)($settings['mailpoet_list_id'] ?? 0),
-            'mailchimp_api_key' => (string)($settings['mailchimp_api_key'] ?? ''),
-            'mailchimp_audience_id' => isset($providerMeta['mailchimp_audience_id']) && $providerMeta['mailchimp_audience_id'] !== '' ? (string)$providerMeta['mailchimp_audience_id'] : (string)($settings['mailchimp_audience_id'] ?? ''),
-            'sendinblue_api_key' => (string)($settings['sendinblue_api_key'] ?? ''),
-            'sendinblue_list_id' => isset($providerMeta['sendinblue_list_id']) && $providerMeta['sendinblue_list_id'] !== '' ? (int)$providerMeta['sendinblue_list_id'] : (int)($settings['sendinblue_list_id'] ?? 0),
-            'convertkit_api_secret' => (string)($settings['convertkit_api_secret'] ?? ''),
-            'convertkit_form_id' => isset($providerMeta['convertkit_form_id']) && $providerMeta['convertkit_form_id'] !== '' ? (int)$providerMeta['convertkit_form_id'] : (int)($settings['convertkit_form_id'] ?? 0),
+        $provider    = ProviderFactory::newsletter( $formId );
+        $settings    = Settings::getSettings();
+        $emailMeta   = get_post_meta( $formId, '_wpbn_email', true );
+        $providerMeta = get_post_meta( $formId, '_wpbn_provider', true );
+        $options     = [
+            'double_opt_in'         => is_array( $emailMeta ) && ! empty( $emailMeta['double_opt_in'] ),
+            'mailpoet_list_id'      => isset( $providerMeta['mailpoet_list_id'] ) && $providerMeta['mailpoet_list_id'] !== '' ? (int) $providerMeta['mailpoet_list_id'] : (int) ( $settings['mailpoet_list_id'] ?? 0 ),
+            'mailchimp_api_key'     => (string) ( $settings['mailchimp_api_key'] ?? '' ),
+            'mailchimp_audience_id' => isset( $providerMeta['mailchimp_audience_id'] ) && $providerMeta['mailchimp_audience_id'] !== '' ? (string) $providerMeta['mailchimp_audience_id'] : (string) ( $settings['mailchimp_audience_id'] ?? '' ),
+            'sendinblue_api_key'    => (string) ( $settings['sendinblue_api_key'] ?? '' ),
+            'sendinblue_list_id'    => isset( $providerMeta['sendinblue_list_id'] ) && $providerMeta['sendinblue_list_id'] !== '' ? (int) $providerMeta['sendinblue_list_id'] : (int) ( $settings['sendinblue_list_id'] ?? 0 ),
+            'convertkit_api_secret' => (string) ( $settings['convertkit_api_secret'] ?? '' ),
+            'convertkit_form_id'    => isset( $providerMeta['convertkit_form_id'] ) && $providerMeta['convertkit_form_id'] !== '' ? (int) $providerMeta['convertkit_form_id'] : (int) ( $settings['convertkit_form_id'] ?? 0 ),
         ];
         $synced = false;
         try {
-            do_action('wpbn_before_provider_sync', $subscriberId, $subscriber, $options);
-            $synced = $provider->upsert([
-                'email' => $subscriber['email'],
-                'first_name' => $subscriber['first_name'],
-                'last_name' => $subscriber['last_name'],
-                'phone' => $subscriber['phone'],
-                'company' => $subscriber['company'],
-                'custom1' => $subscriber['custom1'],
-                'custom2' => $subscriber['custom2'],
-                'form_id' => $formId,
-            ], $options);
-        } catch (\Throwable $e) {
+            do_action( 'wpbn_before_provider_sync', $subscriberId, $subscriber, $options );
+            $synced = $provider->upsert(
+                [
+                    'email'      => $subscriber['email'],
+                    'first_name' => $subscriber['first_name'],
+                    'last_name'  => $subscriber['last_name'],
+                    'phone'      => $subscriber['phone'],
+                    'company'    => $subscriber['company'],
+                    'custom1'    => $subscriber['custom1'],
+                    'custom2'    => $subscriber['custom2'],
+                    'form_id'    => $formId,
+                ],
+                $options
+            );
+        } catch ( \Throwable $e ) {
             $synced = false;
         }
 
-        $wpdb->update($table, [
-            'provider_sync_status' => $synced ? 'synced' : 'failed',
-            'updated_at' => current_time('mysql'),
-        ], ['id' => $subscriberId], ['%s', '%s'], ['%d']);
+        $wpdb->update(
+            $table,
+            [
+                'provider_sync_status' => $synced ? 'synced' : 'failed',
+                'updated_at'           => current_time( 'mysql' ),
+            ],
+            [ 'id' => $subscriberId ],
+            [ '%s', '%s' ],
+            [ '%d' ]
+        );
 
-        do_action('wpbn_after_provider_sync', $subscriberId, (bool)$synced);
+        do_action( 'wpbn_after_provider_sync', $subscriberId, (bool) $synced );
 
-        if ($synced) {
-            self::sendEmails($formId, $subscriber['email']);
+        if ( $synced ) {
+            self::sendEmails( $formId, $subscriber['email'] );
         }
         return $synced;
     }
 
-    private static function sendEmails(int $formId, string $email): void
-    {
-        $emailMeta = get_post_meta($formId, '_wpbn_email', true);
-        $template = is_array($emailMeta) && !empty($emailMeta['email_template']) ? $emailMeta['email_template'] : __('Thank you for subscribing!', 'wpbn');
-        $subject = __('Welcome to our newsletter', 'wpbn');
+    private static function sendEmails( int $formId, string $email ): void {
+        $emailMeta = get_post_meta( $formId, '_wpbn_email', true );
+        $template  = is_array( $emailMeta ) && ! empty( $emailMeta['email_template'] ) ? $emailMeta['email_template'] : __( 'Thank you for subscribing!', 'wpbn' );
+        $subject   = __( 'Welcome to our newsletter', 'wpbn' );
 
-        $headers = ['Content-Type: text/html; charset=UTF-8'];
-        $template = apply_filters('wpbn_welcome_email_template', $template, $formId, $email);
-        $subject = apply_filters('wpbn_welcome_email_subject', $subject, $formId, $email);
+        $headers  = [ 'Content-Type: text/html; charset=UTF-8' ];
+        $template = apply_filters( 'wpbn_welcome_email_template', $template, $formId, $email );
+        $subject  = apply_filters( 'wpbn_welcome_email_subject', $subject, $formId, $email );
 
-        \wp_mail($email, $subject, $template, $headers);
-        do_action('wpbn_welcome_email_sent', $email, $formId);
+        \wp_mail( $email, $subject, $template, $headers );
+        do_action( 'wpbn_welcome_email_sent', $email, $formId );
 
-        $adminEmail = get_option('admin_email');
-        $adminSubject = sprintf(__('New paid subscription: %s', 'wpbn'), $email);
-        $adminBody = sprintf(__('A new subscriber has completed payment on form #%d: %s', 'wpbn'), $formId, $email);
-        \wp_mail($adminEmail, $adminSubject, nl2br(esc_html($adminBody)), $headers);
-        do_action('wpbn_admin_notification_sent', $email, $formId);
+        $adminEmail   = get_option( 'admin_email' );
+        $adminSubject = sprintf( __( 'New paid subscription: %s', 'wpbn' ), $email );
+        $adminBody    = sprintf( __( 'A new subscriber has completed payment on form #%d: %s', 'wpbn' ), $formId, $email );
+        \wp_mail( $adminEmail, $adminSubject, nl2br( esc_html( $adminBody ) ), $headers );
+        do_action( 'wpbn_admin_notification_sent', $email, $formId );
     }
 }
 

--- a/wp-bitcoin-newsletter/src/Services/SyncService.php
+++ b/wp-bitcoin-newsletter/src/Services/SyncService.php
@@ -10,7 +10,17 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
+/**
+ * Synchronization services for payment and newsletter providers.
+ */
 class SyncService {
+    /**
+     * Handle payment marked as paid by provider.
+     *
+     * @param string $invoiceId Invoice identifier.
+     * @param array  $metadata  Optional metadata from webhook.
+     * @return array { ok: bool, redirect?: string, message?: string }
+     */
     public static function handlePaymentPaid( string $invoiceId, array $metadata = [] ): array {
         global $wpdb;
         $table      = Installer::tableName( $wpdb );
@@ -47,6 +57,12 @@ class SyncService {
         return [ 'ok' => true, 'redirect' => $welcomeUrl ];
     }
 
+    /**
+     * Resync a subscriber to the configured newsletter provider.
+     *
+     * @param int $subscriberId Subscriber ID.
+     * @return bool True on success.
+     */
     public static function resync( int $subscriberId ): bool {
         global $wpdb;
         $table      = Installer::tableName( $wpdb );
@@ -109,6 +125,12 @@ class SyncService {
         return $synced;
     }
 
+    /**
+     * Send welcome email to subscriber and admin notification.
+     *
+     * @param int    $formId Form ID.
+     * @param string $email  Subscriber email.
+     */
     private static function send_emails( int $formId, string $email ): void {
         $emailMeta = get_post_meta( $formId, '_wpbn_email', true );
         $template  = is_array( $emailMeta ) && ! empty( $emailMeta['email_template'] ) ? $emailMeta['email_template'] : __( 'Thank you for subscribing!', 'wpbn' );

--- a/wp-bitcoin-newsletter/src/Services/SyncService.php
+++ b/wp-bitcoin-newsletter/src/Services/SyncService.php
@@ -104,12 +104,12 @@ class SyncService {
         do_action( 'wpbn_after_provider_sync', $subscriberId, (bool) $synced );
 
         if ( $synced ) {
-            self::sendEmails( $formId, $subscriber['email'] );
+            self::send_emails( $formId, $subscriber['email'] );
         }
         return $synced;
     }
 
-    private static function sendEmails( int $formId, string $email ): void {
+    private static function send_emails( int $formId, string $email ): void {
         $emailMeta = get_post_meta( $formId, '_wpbn_email', true );
         $template  = is_array( $emailMeta ) && ! empty( $emailMeta['email_template'] ) ? $emailMeta['email_template'] : __( 'Thank you for subscribing!', 'wpbn' );
         $subject   = __( 'Welcome to our newsletter', 'wpbn' );

--- a/wp-bitcoin-newsletter/src/Services/SyncService.php
+++ b/wp-bitcoin-newsletter/src/Services/SyncService.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Synchronization services for payment and newsletter providers.
+ *
+ * @package wp-bitcoin-newsletter
+ */
+declare(strict_types=1);
 
 namespace WpBitcoinNewsletter\Services;
 
@@ -10,25 +16,24 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-/**
- * Synchronization services for payment and newsletter providers.
- */
 class SyncService {
     /**
      * Handle payment marked as paid by provider.
      *
-     * @param string $invoiceId Invoice identifier.
-     * @param array  $metadata  Optional metadata from webhook.
+     * @param string $invoice_id Invoice identifier.
+     * @param array  $metadata   Optional metadata from webhook.
      * @return array { ok: bool, redirect?: string, message?: string }
      */
-    public static function handlePaymentPaid( string $invoiceId, array $metadata = [] ): array {
+    public static function handle_payment_paid( string $invoice_id, array $metadata = [] ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
         global $wpdb;
         $table      = Installer::tableName( $wpdb );
-        $subscriber = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE payment_invoice_id = %s LIMIT 1", $invoiceId ), ARRAY_A );
+        // Table name is trusted, values are placeholders.
+        // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+        $subscriber = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE payment_invoice_id = %s LIMIT 1", $invoice_id ), ARRAY_A );
         if ( ! $subscriber ) {
             return [ 'ok' => false, 'message' => 'Invoice not found' ];
         }
-        if ( $subscriber['payment_status'] === 'paid' ) {
+        if ( 'paid' === $subscriber['payment_status'] ) {
             // Already paid; still ensure provider sync.
             self::resync( (int) $subscriber['id'] );
             return [ 'ok' => true, 'message' => 'Already paid' ];
@@ -47,48 +52,49 @@ class SyncService {
             [ '%d' ]
         );
 
-        do_action( 'wpbn_payment_marked_paid', $invoiceId, $subscriber );
+        do_action( 'wpbn_payment_marked_paid', $invoice_id, $subscriber );
 
         self::resync( (int) $subscriber['id'] );
 
-        $welcome    = get_post_meta( (int) $subscriber['form_id'], '_wpbn_email', true );
-        $welcomeUrl = is_array( $welcome ) && ! empty( $welcome['welcome_url'] ) ? esc_url_raw( $welcome['welcome_url'] ) : home_url( '/' );
+        $welcome     = get_post_meta( (int) $subscriber['form_id'], '_wpbn_email', true );
+        $welcome_url = is_array( $welcome ) && ! empty( $welcome['welcome_url'] ) ? esc_url_raw( $welcome['welcome_url'] ) : home_url( '/' );
 
-        return [ 'ok' => true, 'redirect' => $welcomeUrl ];
+        return [ 'ok' => true, 'redirect' => $welcome_url ];
     }
 
     /**
      * Resync a subscriber to the configured newsletter provider.
      *
-     * @param int $subscriberId Subscriber ID.
+     * @param int $subscriber_id Subscriber ID.
      * @return bool True on success.
      */
-    public static function resync( int $subscriberId ): bool {
+    public static function resync( int $subscriber_id ): bool {
         global $wpdb;
         $table      = Installer::tableName( $wpdb );
-        $subscriber = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d", $subscriberId ), ARRAY_A );
+        // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+        $subscriber = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d", $subscriber_id ), ARRAY_A );
         if ( ! $subscriber ) {
             return false;
         }
-        $formId = (int) $subscriber['form_id'];
+        $form_id = (int) $subscriber['form_id'];
 
-        $provider    = ProviderFactory::newsletter( $formId );
-        $settings    = Settings::getSettings();
-        $emailMeta   = get_post_meta( $formId, '_wpbn_email', true );
-        $providerMeta = get_post_meta( $formId, '_wpbn_provider', true );
+        $provider     = ProviderFactory::newsletter( $form_id );
+        $settings     = Settings::getSettings();
+        $email_meta   = get_post_meta( $form_id, '_wpbn_email', true );
+        $provider_meta = get_post_meta( $form_id, '_wpbn_provider', true );
         $options     = [
-            'double_opt_in'         => is_array( $emailMeta ) && ! empty( $emailMeta['double_opt_in'] ),
-            'mailpoet_list_id'      => isset( $providerMeta['mailpoet_list_id'] ) && $providerMeta['mailpoet_list_id'] !== '' ? (int) $providerMeta['mailpoet_list_id'] : (int) ( $settings['mailpoet_list_id'] ?? 0 ),
+            'double_opt_in'         => is_array( $email_meta ) && ! empty( $email_meta['double_opt_in'] ),
+            'mailpoet_list_id'      => isset( $provider_meta['mailpoet_list_id'] ) && '' !== $provider_meta['mailpoet_list_id'] ? (int) $provider_meta['mailpoet_list_id'] : (int) ( $settings['mailpoet_list_id'] ?? 0 ),
             'mailchimp_api_key'     => (string) ( $settings['mailchimp_api_key'] ?? '' ),
-            'mailchimp_audience_id' => isset( $providerMeta['mailchimp_audience_id'] ) && $providerMeta['mailchimp_audience_id'] !== '' ? (string) $providerMeta['mailchimp_audience_id'] : (string) ( $settings['mailchimp_audience_id'] ?? '' ),
+            'mailchimp_audience_id' => isset( $provider_meta['mailchimp_audience_id'] ) && '' !== $provider_meta['mailchimp_audience_id'] ? (string) $provider_meta['mailchimp_audience_id'] : (string) ( $settings['mailchimp_audience_id'] ?? '' ),
             'sendinblue_api_key'    => (string) ( $settings['sendinblue_api_key'] ?? '' ),
-            'sendinblue_list_id'    => isset( $providerMeta['sendinblue_list_id'] ) && $providerMeta['sendinblue_list_id'] !== '' ? (int) $providerMeta['sendinblue_list_id'] : (int) ( $settings['sendinblue_list_id'] ?? 0 ),
+            'sendinblue_list_id'    => isset( $provider_meta['sendinblue_list_id'] ) && '' !== $provider_meta['sendinblue_list_id'] ? (int) $provider_meta['sendinblue_list_id'] : (int) ( $settings['sendinblue_list_id'] ?? 0 ),
             'convertkit_api_secret' => (string) ( $settings['convertkit_api_secret'] ?? '' ),
-            'convertkit_form_id'    => isset( $providerMeta['convertkit_form_id'] ) && $providerMeta['convertkit_form_id'] !== '' ? (int) $providerMeta['convertkit_form_id'] : (int) ( $settings['convertkit_form_id'] ?? 0 ),
+            'convertkit_form_id'    => isset( $provider_meta['convertkit_form_id'] ) && '' !== $provider_meta['convertkit_form_id'] ? (int) $provider_meta['convertkit_form_id'] : (int) ( $settings['convertkit_form_id'] ?? 0 ),
         ];
         $synced = false;
         try {
-            do_action( 'wpbn_before_provider_sync', $subscriberId, $subscriber, $options );
+            do_action( 'wpbn_before_provider_sync', $subscriber_id, $subscriber, $options );
             $synced = $provider->upsert(
                 [
                     'email'      => $subscriber['email'],
@@ -98,7 +104,7 @@ class SyncService {
                     'company'    => $subscriber['company'],
                     'custom1'    => $subscriber['custom1'],
                     'custom2'    => $subscriber['custom2'],
-                    'form_id'    => $formId,
+                    'form_id'    => $form_id,
                 ],
                 $options
             );
@@ -112,15 +118,15 @@ class SyncService {
                 'provider_sync_status' => $synced ? 'synced' : 'failed',
                 'updated_at'           => current_time( 'mysql' ),
             ],
-            [ 'id' => $subscriberId ],
+            [ 'id' => $subscriber_id ],
             [ '%s', '%s' ],
             [ '%d' ]
         );
 
-        do_action( 'wpbn_after_provider_sync', $subscriberId, (bool) $synced );
+        do_action( 'wpbn_after_provider_sync', $subscriber_id, (bool) $synced );
 
         if ( $synced ) {
-            self::send_emails( $formId, $subscriber['email'] );
+            self::send_emails( $form_id, $subscriber['email'] );
         }
         return $synced;
     }
@@ -128,26 +134,28 @@ class SyncService {
     /**
      * Send welcome email to subscriber and admin notification.
      *
-     * @param int    $formId Form ID.
+     * @param int    $form_id Form ID.
      * @param string $email  Subscriber email.
      */
-    private static function send_emails( int $formId, string $email ): void {
-        $emailMeta = get_post_meta( $formId, '_wpbn_email', true );
-        $template  = is_array( $emailMeta ) && ! empty( $emailMeta['email_template'] ) ? $emailMeta['email_template'] : __( 'Thank you for subscribing!', 'wpbn' );
+    private static function send_emails( int $form_id, string $email ): void {
+        $email_meta = get_post_meta( $form_id, '_wpbn_email', true );
+        $template  = is_array( $email_meta ) && ! empty( $email_meta['email_template'] ) ? $email_meta['email_template'] : __( 'Thank you for subscribing!', 'wpbn' );
         $subject   = __( 'Welcome to our newsletter', 'wpbn' );
 
         $headers  = [ 'Content-Type: text/html; charset=UTF-8' ];
-        $template = apply_filters( 'wpbn_welcome_email_template', $template, $formId, $email );
-        $subject  = apply_filters( 'wpbn_welcome_email_subject', $subject, $formId, $email );
+        $template = apply_filters( 'wpbn_welcome_email_template', $template, $form_id, $email );
+        $subject  = apply_filters( 'wpbn_welcome_email_subject', $subject, $form_id, $email );
 
         \wp_mail( $email, $subject, $template, $headers );
-        do_action( 'wpbn_welcome_email_sent', $email, $formId );
+        do_action( 'wpbn_welcome_email_sent', $email, $form_id );
 
-        $adminEmail   = get_option( 'admin_email' );
-        $adminSubject = sprintf( __( 'New paid subscription: %s', 'wpbn' ), $email );
-        $adminBody    = sprintf( __( 'A new subscriber has completed payment on form #%d: %s', 'wpbn' ), $formId, $email );
-        \wp_mail( $adminEmail, $adminSubject, nl2br( esc_html( $adminBody ) ), $headers );
-        do_action( 'wpbn_admin_notification_sent', $email, $formId );
+        $admin_email   = get_option( 'admin_email' );
+        /* translators: %s email address */
+        $admin_subject = sprintf( __( 'New paid subscription: %s', 'wpbn' ), $email );
+        /* translators: 1: form id, 2: email */
+        $admin_body    = sprintf( __( 'A new subscriber has completed payment on form #%d: %s', 'wpbn' ), $form_id, $email );
+        \wp_mail( $admin_email, $admin_subject, nl2br( esc_html( $admin_body ) ), $headers );
+        do_action( 'wpbn_admin_notification_sent', $email, $form_id );
     }
 }
 

--- a/wp-bitcoin-newsletter/src/Shortcode/FormShortcode.php
+++ b/wp-bitcoin-newsletter/src/Shortcode/FormShortcode.php
@@ -1,10 +1,10 @@
 <?php
-declare(strict_types=1);
 /**
  * Shortcode handling.
  *
  * @package wp-bitcoin-newsletter
  */
+declare(strict_types=1);
 
 namespace WpBitcoinNewsletter\Shortcode;
 

--- a/wp-bitcoin-newsletter/src/Shortcode/FormShortcode.php
+++ b/wp-bitcoin-newsletter/src/Shortcode/FormShortcode.php
@@ -1,4 +1,10 @@
 <?php
+declare(strict_types=1);
+/**
+ * Shortcode handling.
+ *
+ * @package wp-bitcoin-newsletter
+ */
 
 namespace WpBitcoinNewsletter\Shortcode;
 

--- a/wp-bitcoin-newsletter/src/Shortcode/FormShortcode.php
+++ b/wp-bitcoin-newsletter/src/Shortcode/FormShortcode.php
@@ -6,119 +6,124 @@ use WpBitcoinNewsletter\CPT\FormPostType;
 use WpBitcoinNewsletter\Database\Installer;
 use WpBitcoinNewsletter\Util\ProviderFactory;
 
-defined('ABSPATH') || exit;
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
 
-class FormShortcode
-{
-    public static function register(): void
-    {
-        add_shortcode('coinsnap_newsletter_form', [__CLASS__, 'render']);
-        add_action('wp_ajax_wpbn_submit_form', [__CLASS__, 'handleSubmit']);
-        add_action('wp_ajax_nopriv_wpbn_submit_form', [__CLASS__, 'handleSubmit']);
+class FormShortcode {
+    public static function register(): void {
+        add_shortcode( 'coinsnap_newsletter_form', [ __CLASS__, 'render' ] );
+        add_action( 'wp_ajax_wpbn_submit_form', [ __CLASS__, 'handleSubmit' ] );
+        add_action( 'wp_ajax_nopriv_wpbn_submit_form', [ __CLASS__, 'handleSubmit' ] );
     }
 
-    public static function render($atts): string
-    {
-        $atts = shortcode_atts([
-            'id' => 0,
-        ], $atts, 'coinsnap_newsletter_form');
+    public static function render( $atts ): string {
+        $atts = shortcode_atts(
+            [
+                'id' => 0,
+            ],
+            $atts,
+            'coinsnap_newsletter_form'
+        );
 
-        $postId = absint($atts['id']);
-        if (!$postId || get_post_type($postId) !== FormPostType::POST_TYPE) {
+        $postId = absint( $atts['id'] );
+        if ( ! $postId || get_post_type( $postId ) !== FormPostType::POST_TYPE ) {
             return '';
         }
 
-        $fields = get_post_meta($postId, '_wpbn_fields', true);
-        if (!is_array($fields)) {
+        $fields = get_post_meta( $postId, '_wpbn_fields', true );
+        if ( ! is_array( $fields ) ) {
             $fields = [];
         }
-        $gdpr = get_post_meta($postId, '_wpbn_gdpr', true);
-        if (!is_array($gdpr)) {
+        $gdpr = get_post_meta( $postId, '_wpbn_gdpr', true );
+        if ( ! is_array( $gdpr ) ) {
             $gdpr = [];
         }
-        $gdprText = isset($gdpr['gdpr_text']) && $gdpr['gdpr_text'] ? $gdpr['gdpr_text'] : __('I consent to receive newsletters and accept the privacy policy.', 'wpbn');
-        $privacyUrl = isset($gdpr['privacy_policy_url']) ? esc_url($gdpr['privacy_policy_url']) : '';
+        $gdprText  = isset( $gdpr['gdpr_text'] ) && $gdpr['gdpr_text'] ? $gdpr['gdpr_text'] : __( 'I consent to receive newsletters and accept the privacy policy.', 'wpbn' );
+        $privacyUrl = isset( $gdpr['privacy_policy_url'] ) ? esc_url( $gdpr['privacy_policy_url'] ) : '';
 
-        $nonce = wp_create_nonce('wpbn_form_' . $postId);
+        $nonce        = wp_create_nonce( 'wpbn_form_' . $postId );
         $honeypotName = 'website';
 
-        $ordered = self::buildOrderedFields($fields);
+        $ordered = self::buildOrderedFields( $fields );
 
         ob_start();
-        echo '<form class="wpbn-form" method="post" action="' . esc_url(admin_url('admin-ajax.php')) . '" data-form-id="' . esc_attr($postId) . '">';
+        echo '<form class="wpbn-form" method="post" action="' . esc_url( admin_url( 'admin-ajax.php' ) ) . '" data-form-id="' . esc_attr( $postId ) . '">';
         echo '<input type="hidden" name="action" value="wpbn_submit_form" />';
-        echo '<input type="hidden" name="wpbn_form_id" value="' . esc_attr($postId) . '" />';
-        echo '<input type="hidden" name="wpbn_nonce" value="' . esc_attr($nonce) . '" />';
-        echo '<div style="position:absolute;left:-9999px;top:-9999px;"><label>' . esc_html__('Do not fill this out', 'wpbn') . ' <input type="text" name="' . esc_attr($honeypotName) . '" value="" /></label></div>';
+        echo '<input type="hidden" name="wpbn_form_id" value="' . esc_attr( $postId ) . '" />';
+        echo '<input type="hidden" name="wpbn_nonce" value="' . esc_attr( $nonce ) . '" />';
+        echo '<div style="position:absolute;left:-9999px;top:-9999px;"><label>' . esc_html__( 'Do not fill this out', 'wpbn' ) . ' <input type="text" name="' . esc_attr( $honeypotName ) . '" value="" /></label></div>';
 
-        // Email (always required)
-        $emailLabel = isset($fields['email_label']) ? $fields['email_label'] : __('Email Address', 'wpbn');
-        echo '<p class="wpbn-field"><label>' . esc_html($emailLabel) . ' <span class="required">*</span><br /><input type="email" name="email" required /></label></p>';
+        // Email (always required).
+        $emailLabel = isset( $fields['email_label'] ) ? $fields['email_label'] : __( 'Email Address', 'wpbn' );
+        echo '<p class="wpbn-field"><label>' . esc_html( $emailLabel ) . ' <span class="required">*</span><br /><input type="email" name="email" required /></label></p>';
 
-        foreach ($ordered as $field) {
-            echo self::renderField($field);
+        foreach ( $ordered as $field ) {
+            echo self::renderField( $field );
         }
 
-        echo '<p class="wpbn-gdpr"><label><input type="checkbox" name="gdpr_consent" value="1" required /> ' . wp_kses_post($gdprText);
-        if ($privacyUrl) {
-            echo ' <a href="' . esc_url($privacyUrl) . '" target="_blank" rel="noopener noreferrer">' . esc_html__('Privacy Policy', 'wpbn') . '</a>';
+        echo '<p class="wpbn-gdpr"><label><input type="checkbox" name="gdpr_consent" value="1" required /> ' . wp_kses_post( $gdprText );
+        if ( $privacyUrl ) {
+            echo ' <a href="' . esc_url( $privacyUrl ) . '" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Privacy Policy', 'wpbn' ) . '</a>';
         }
         echo '</label></p>';
 
-        echo '<p><button type="submit" class="wpbn-submit">' . esc_html__('Continue to Payment', 'wpbn') . '</button></p>';
+        echo '<p><button type="submit" class="wpbn-submit">' . esc_html__( 'Continue to Payment', 'wpbn' ) . '</button></p>';
         echo '</form>';
-        $html = (string)ob_get_clean();
+        $html = (string) ob_get_clean();
         /**
          * Filter the rendered form HTML.
-         * @param string $html
-         * @param int $formId
+         *
+         * @param string $html   Rendered HTML.
+         * @param int    $formId Form ID.
          */
-        return apply_filters('wpbn_form_html', $html, $postId);
+        return apply_filters( 'wpbn_form_html', $html, $postId );
     }
 
-    private static function buildOrderedFields(array $fields): array
-    {
-        $map = [];
+    private static function buildOrderedFields( array $fields ): array {
+        $map       = [];
         $candidates = [
-            'first_name' => __('First Name', 'wpbn'),
-            'last_name' => __('Last Name', 'wpbn'),
-            'phone' => __('Phone Number', 'wpbn'),
-            'company' => __('Company', 'wpbn'),
-            'custom1' => __('Custom Field 1', 'wpbn'),
-            'custom2' => __('Custom Field 2', 'wpbn'),
+            'first_name' => __( 'First Name', 'wpbn' ),
+            'last_name'  => __( 'Last Name', 'wpbn' ),
+            'phone'      => __( 'Phone Number', 'wpbn' ),
+            'company'    => __( 'Company', 'wpbn' ),
+            'custom1'    => __( 'Custom Field 1', 'wpbn' ),
+            'custom2'    => __( 'Custom Field 2', 'wpbn' ),
         ];
-        foreach ($candidates as $slug => $fallbackLabel) {
-            $enabled = isset($fields[$slug . '_enabled']) && $fields[$slug . '_enabled'];
-            if (!$enabled) {
+        foreach ( $candidates as $slug => $fallbackLabel ) {
+            $enabled = isset( $fields[ $slug . '_enabled' ] ) && $fields[ $slug . '_enabled' ];
+            if ( ! $enabled ) {
                 continue;
             }
             $map[] = [
-                'slug' => $slug,
-                'label' => isset($fields[$slug . '_label']) && $fields[$slug . '_label'] ? $fields[$slug . '_label'] : $fallbackLabel,
-                'required' => !empty($fields[$slug . '_required']),
-                'order' => isset($fields[$slug . '_order']) ? (int)$fields[$slug . '_order'] : 100,
-                'type' => isset($fields[$slug . '_type']) ? $fields[$slug . '_type'] : 'text',
-                'options' => isset($fields[$slug . '_options']) ? $fields[$slug . '_options'] : '',
+                'slug'     => $slug,
+                'label'    => isset( $fields[ $slug . '_label' ] ) && $fields[ $slug . '_label' ] ? $fields[ $slug . '_label' ] : $fallbackLabel,
+                'required' => ! empty( $fields[ $slug . '_required' ] ),
+                'order'    => isset( $fields[ $slug . '_order' ] ) ? (int) $fields[ $slug . '_order' ] : 100,
+                'type'     => isset( $fields[ $slug . '_type' ] ) ? $fields[ $slug . '_type' ] : 'text',
+                'options'  => isset( $fields[ $slug . '_options' ] ) ? $fields[ $slug . '_options' ] : '',
             ];
         }
-        usort($map, function ($a, $b) {
-            return ($a['order'] <=> $b['order']);
-        });
+        usort(
+            $map,
+            function ( $a, $b ) {
+                return ( $a['order'] <=> $b['order'] );
+            }
+        );
         return $map;
     }
 
-    private static function renderField(array $field): string
-    {
-        $required = $field['required'] ? ' required' : '';
+    private static function renderField( array $field ): string {
+        $required     = $field['required'] ? ' required' : '';
         $requiredMark = $field['required'] ? ' <span class="required">*</span>' : '';
-        $name = esc_attr($field['slug']);
-        $label = esc_html($field['label']);
+        $name         = esc_attr( $field['slug'] );
+        $label        = esc_html( $field['label'] );
 
-        if (in_array($field['slug'], ['custom1', 'custom2'], true) && $field['type'] === 'select') {
-            $options = array_filter(array_map('trim', explode(',', (string)$field['options'])));
-            $html = '<p class="wpbn-field"><label>' . $label . $requiredMark . '<br /><select name="' . $name . '"' . $required . '>';
-            foreach ($options as $opt) {
-                $html .= '<option value="' . esc_attr($opt) . '">' . esc_html($opt) . '</option>';
+        if ( in_array( $field['slug'], [ 'custom1', 'custom2' ], true ) && $field['type'] === 'select' ) {
+            $options = array_filter( array_map( 'trim', explode( ',', (string) $field['options'] ) ) );
+            $html    = '<p class="wpbn-field"><label>' . $label . $requiredMark . '<br /><select name="' . $name . '"' . $required . '>';
+            foreach ( $options as $opt ) {
+                $html .= '<option value="' . esc_attr( $opt ) . '">' . esc_html( $opt ) . '</option>';
             }
             $html .= '</select></label></p>';
             return $html;
@@ -127,126 +132,130 @@ class FormShortcode
         return '<p class="wpbn-field"><label>' . $label . $requiredMark . '<br /><input type="text" name="' . $name . '"' . $required . ' /></label></p>';
     }
 
-    public static function handleSubmit(): void
-    {
-        \check_ajax_referer('wpbn_form_' . (isset($_POST['wpbn_form_id']) ? absint($_POST['wpbn_form_id']) : 0), 'wpbn_nonce');
+    public static function handleSubmit(): void {
+        \check_ajax_referer( 'wpbn_form_' . ( isset( $_POST['wpbn_form_id'] ) ? absint( $_POST['wpbn_form_id'] ) : 0 ), 'wpbn_nonce' );
 
-        $formId = isset($_POST['wpbn_form_id']) ? absint($_POST['wpbn_form_id']) : 0;
-        if (!$formId || get_post_type($formId) !== FormPostType::POST_TYPE) {
-            wp_send_json_error(['message' => __('Invalid form.', 'wpbn')], 400);
+        $formId = isset( $_POST['wpbn_form_id'] ) ? absint( $_POST['wpbn_form_id'] ) : 0;
+        if ( ! $formId || get_post_type( $formId ) !== FormPostType::POST_TYPE ) {
+            wp_send_json_error( [ 'message' => __( 'Invalid form.', 'wpbn' ) ], 400 );
         }
-        if (!empty($_POST['website'])) {
-            wp_send_json_error(['message' => __('Spam detected.', 'wpbn')], 400);
-        }
-
-        // Simple IP rate limit: 1 request per 10 seconds per IP per form
-        $ip = isset($_SERVER['REMOTE_ADDR']) ? sanitize_text_field($_SERVER['REMOTE_ADDR']) : '';
-        $key = 'wpbn_rl_' . md5($formId . '|' . $ip);
-        if (get_transient($key)) {
-            wp_send_json_error(['message' => __('Please wait a few seconds before trying again.', 'wpbn')], 429);
-        }
-        set_transient($key, 1, 10);
-
-        $email = isset($_POST['email']) ? sanitize_email(wp_unslash($_POST['email'])) : '';
-        if (!$email || !is_email($email)) {
-            wp_send_json_error(['message' => __('Please provide a valid email address.', 'wpbn')], 422);
+        if ( ! empty( $_POST['website'] ) ) {
+            wp_send_json_error( [ 'message' => __( 'Spam detected.', 'wpbn' ) ], 400 );
         }
 
-        $fields = get_post_meta($formId, '_wpbn_fields', true);
-        if (!is_array($fields)) {
+        // Simple IP rate limit: 1 request per 10 seconds per IP per form.
+        $ip  = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
+        $key = 'wpbn_rl_' . md5( $formId . '|' . $ip );
+        if ( get_transient( $key ) ) {
+            wp_send_json_error( [ 'message' => __( 'Please wait a few seconds before trying again.', 'wpbn' ) ], 429 );
+        }
+        set_transient( $key, 1, 10 );
+
+        $email = isset( $_POST['email'] ) ? sanitize_email( wp_unslash( $_POST['email'] ) ) : '';
+        if ( ! $email || ! is_email( $email ) ) {
+            wp_send_json_error( [ 'message' => __( 'Please provide a valid email address.', 'wpbn' ) ], 422 );
+        }
+
+        $fields = get_post_meta( $formId, '_wpbn_fields', true );
+        if ( ! is_array( $fields ) ) {
             $fields = [];
         }
 
         $data = [
-            'email' => $email,
-            'first_name' => isset($_POST['first_name']) ? sanitize_text_field(wp_unslash($_POST['first_name'])) : '',
-            'last_name' => isset($_POST['last_name']) ? sanitize_text_field(wp_unslash($_POST['last_name'])) : '',
-            'phone' => isset($_POST['phone']) ? sanitize_text_field(wp_unslash($_POST['phone'])) : '',
-            'company' => isset($_POST['company']) ? sanitize_text_field(wp_unslash($_POST['company'])) : '',
-            'custom1' => isset($_POST['custom1']) ? sanitize_text_field(wp_unslash($_POST['custom1'])) : '',
-            'custom2' => isset($_POST['custom2']) ? sanitize_text_field(wp_unslash($_POST['custom2'])) : '',
-            'gdpr_consent' => !empty($_POST['gdpr_consent']) ? 1 : 0,
+            'email'       => $email,
+            'first_name'  => isset( $_POST['first_name'] ) ? sanitize_text_field( wp_unslash( $_POST['first_name'] ) ) : '',
+            'last_name'   => isset( $_POST['last_name'] ) ? sanitize_text_field( wp_unslash( $_POST['last_name'] ) ) : '',
+            'phone'       => isset( $_POST['phone'] ) ? sanitize_text_field( wp_unslash( $_POST['phone'] ) ) : '',
+            'company'     => isset( $_POST['company'] ) ? sanitize_text_field( wp_unslash( $_POST['company'] ) ) : '',
+            'custom1'     => isset( $_POST['custom1'] ) ? sanitize_text_field( wp_unslash( $_POST['custom1'] ) ) : '',
+            'custom2'     => isset( $_POST['custom2'] ) ? sanitize_text_field( wp_unslash( $_POST['custom2'] ) ) : '',
+            'gdpr_consent'=> ! empty( $_POST['gdpr_consent'] ) ? 1 : 0,
         ];
         /**
          * Filter form submission data before insert.
-         * @param array $data
-         * @param int $formId
+         *
+         * @param array $data   Submission data.
+         * @param int   $formId Form ID.
          */
-        $data = apply_filters('wpbn_form_submission_data', $data, $formId);
+        $data = apply_filters( 'wpbn_form_submission_data', $data, $formId );
 
-        if (!$data['gdpr_consent']) {
-            wp_send_json_error(['message' => __('GDPR consent is required.', 'wpbn')], 422);
+        if ( ! $data['gdpr_consent'] ) {
+            wp_send_json_error( [ 'message' => __( 'GDPR consent is required.', 'wpbn' ) ], 422 );
         }
 
         global $wpdb;
-        $table = Installer::tableName($wpdb);
+        $table = Installer::tableName( $wpdb );
         /** Action: before subscriber insert */
-        do_action('wpbn_before_subscriber_insert', $data, $formId);
+        do_action( 'wpbn_before_subscriber_insert', $data, $formId );
         $inserted = $wpdb->insert(
             $table,
             [
-                'form_id' => $formId,
-                'email' => $data['email'],
-                'first_name' => $data['first_name'],
-                'last_name' => $data['last_name'],
-                'phone' => $data['phone'],
-                'company' => $data['company'],
-                'custom1' => $data['custom1'],
-                'custom2' => $data['custom2'],
-                'gdpr_consent' => $data['gdpr_consent'],
-                'ip' => $ip,
-                'user_agent' => isset($_SERVER['HTTP_USER_AGENT']) ? sanitize_textarea_field($_SERVER['HTTP_USER_AGENT']) : '',
-                'payment_status' => 'unpaid',
+                'form_id'              => $formId,
+                'email'                => $data['email'],
+                'first_name'           => $data['first_name'],
+                'last_name'            => $data['last_name'],
+                'phone'                => $data['phone'],
+                'company'              => $data['company'],
+                'custom1'              => $data['custom1'],
+                'custom2'              => $data['custom2'],
+                'gdpr_consent'         => $data['gdpr_consent'],
+                'ip'                   => $ip,
+                'user_agent'           => isset( $_SERVER['HTTP_USER_AGENT'] ) ? sanitize_textarea_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) : '',
+                'payment_status'       => 'unpaid',
                 'provider_sync_status' => 'pending',
             ],
             [
-                '%d', '%s', '%s', '%s', '%s', '%s', '%s', '%d', '%s', '%s', '%s', '%s'
+                '%d', '%s', '%s', '%s', '%s', '%s', '%s', '%d', '%s', '%s', '%s', '%s',
             ]
         );
 
-        if (!$inserted) {
-            wp_send_json_error(['message' => __('Could not create subscriber.', 'wpbn')], 500);
+        if ( ! $inserted ) {
+            wp_send_json_error( [ 'message' => __( 'Could not create subscriber.', 'wpbn' ) ], 500 );
         }
 
-        $subscriberId = (int)$wpdb->insert_id;
-        do_action('wpbn_subscriber_created', $subscriberId, $formId, $data);
+        $subscriberId = (int) $wpdb->insert_id;
+        do_action( 'wpbn_subscriber_created', $subscriberId, $formId, $data );
 
-        // Determine amount/currency and create invoice via selected provider
-        $payment = get_post_meta($formId, '_wpbn_payment', true);
-        if (!is_array($payment)) $payment = [];
-        $amount = isset($payment['amount']) ? absint($payment['amount']) : 21;
-        $currency = isset($payment['currency']) ? sanitize_text_field($payment['currency']) : 'SATS';
-        $params = apply_filters('wpbn_payment_parameters', ['amount' => $amount, 'currency' => $currency], $formId, $data);
-        $amount = isset($params['amount']) ? (int)$params['amount'] : $amount;
-        $currency = isset($params['currency']) ? (string)$params['currency'] : $currency;
+        // Determine amount/currency and create invoice via selected provider.
+        $payment = get_post_meta( $formId, '_wpbn_payment', true );
+        if ( ! is_array( $payment ) ) {
+            $payment = [];
+        }
+        $amount   = isset( $payment['amount'] ) ? absint( $payment['amount'] ) : 21;
+        $currency = isset( $payment['currency'] ) ? sanitize_text_field( $payment['currency'] ) : 'SATS';
+        $params   = apply_filters( 'wpbn_payment_parameters', [ 'amount' => $amount, 'currency' => $currency ], $formId, $data );
+        $amount   = isset( $params['amount'] ) ? (int) $params['amount'] : $amount;
+        $currency = isset( $params['currency'] ) ? (string) $params['currency'] : $currency;
 
-        $provider = ProviderFactory::paymentForForm($formId);
-        $invoice = $provider->createInvoice($formId, $amount, $currency, $data);
-        $invoiceId = isset($invoice['invoice_id']) ? (string)$invoice['invoice_id'] : '';
-        $paymentUrl = isset($invoice['payment_url']) ? (string)$invoice['payment_url'] : '';
+        $provider  = ProviderFactory::paymentForForm( $formId );
+        $invoice   = $provider->createInvoice( $formId, $amount, $currency, $data );
+        $invoiceId = isset( $invoice['invoice_id'] ) ? (string) $invoice['invoice_id'] : '';
+        $paymentUrl = isset( $invoice['payment_url'] ) ? (string) $invoice['payment_url'] : '';
 
-        if (!$invoiceId || !$paymentUrl) {
-            wp_send_json_error(['message' => __('Failed to create invoice.', 'wpbn')], 500);
+        if ( ! $invoiceId || ! $paymentUrl ) {
+            wp_send_json_error( [ 'message' => __( 'Failed to create invoice.', 'wpbn' ) ], 500 );
         }
 
         $wpdb->update(
             $table,
             [
                 'payment_invoice_id' => $invoiceId,
-                'payment_provider' => is_object($provider) ? strtolower((new \ReflectionClass($provider))->getShortName()) : '',
-                'payment_amount' => $amount,
-                'currency' => $currency,
+                'payment_provider'   => is_object( $provider ) ? strtolower( ( new \ReflectionClass( $provider ) )->getShortName() ) : '',
+                'payment_amount'     => $amount,
+                'currency'           => $currency,
             ],
-            ['id' => $subscriberId],
-            ['%s', '%s', '%d', '%s'],
-            ['%d']
+            [ 'id' => $subscriberId ],
+            [ '%s', '%s', '%d', '%s' ],
+            [ '%d' ]
         );
 
-        wp_send_json_success([
-            'invoice_id' => $invoiceId,
-            'payment_url' => add_query_arg(['wpbn_invoice' => $invoiceId], $paymentUrl),
-            'subscriber_id' => $subscriberId,
-        ]);
+        wp_send_json_success(
+            [
+                'invoice_id'    => $invoiceId,
+                'payment_url'   => add_query_arg( [ 'wpbn_invoice' => $invoiceId ], $paymentUrl ),
+                'subscriber_id' => $subscriberId,
+            ]
+        );
     }
 }
 

--- a/wp-bitcoin-newsletter/src/Shortcode/FormShortcode.php
+++ b/wp-bitcoin-newsletter/src/Shortcode/FormShortcode.php
@@ -13,8 +13,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 class FormShortcode {
     public static function register(): void {
         add_shortcode( 'coinsnap_newsletter_form', [ __CLASS__, 'render' ] );
-        add_action( 'wp_ajax_wpbn_submit_form', [ __CLASS__, 'handleSubmit' ] );
-        add_action( 'wp_ajax_nopriv_wpbn_submit_form', [ __CLASS__, 'handleSubmit' ] );
+        add_action( 'wp_ajax_wpbn_submit_form', [ __CLASS__, 'handle_submit' ] );
+        add_action( 'wp_ajax_nopriv_wpbn_submit_form', [ __CLASS__, 'handle_submit' ] );
     }
 
     public static function render( $atts ): string {
@@ -45,7 +45,7 @@ class FormShortcode {
         $nonce        = wp_create_nonce( 'wpbn_form_' . $postId );
         $honeypotName = 'website';
 
-        $ordered = self::buildOrderedFields( $fields );
+        $ordered = self::build_ordered_fields( $fields );
 
         ob_start();
         echo '<form class="wpbn-form" method="post" action="' . esc_url( admin_url( 'admin-ajax.php' ) ) . '" data-form-id="' . esc_attr( $postId ) . '">';
@@ -59,7 +59,7 @@ class FormShortcode {
         echo '<p class="wpbn-field"><label>' . esc_html( $emailLabel ) . ' <span class="required">*</span><br /><input type="email" name="email" required /></label></p>';
 
         foreach ( $ordered as $field ) {
-            echo self::renderField( $field );
+            echo self::render_field( $field );
         }
 
         echo '<p class="wpbn-gdpr"><label><input type="checkbox" name="gdpr_consent" value="1" required /> ' . wp_kses_post( $gdprText );
@@ -80,7 +80,7 @@ class FormShortcode {
         return apply_filters( 'wpbn_form_html', $html, $postId );
     }
 
-    private static function buildOrderedFields( array $fields ): array {
+    private static function build_ordered_fields( array $fields ): array {
         $map       = [];
         $candidates = [
             'first_name' => __( 'First Name', 'wpbn' ),
@@ -113,7 +113,7 @@ class FormShortcode {
         return $map;
     }
 
-    private static function renderField( array $field ): string {
+    private static function render_field( array $field ): string {
         $required     = $field['required'] ? ' required' : '';
         $requiredMark = $field['required'] ? ' <span class="required">*</span>' : '';
         $name         = esc_attr( $field['slug'] );
@@ -132,7 +132,7 @@ class FormShortcode {
         return '<p class="wpbn-field"><label>' . $label . $requiredMark . '<br /><input type="text" name="' . $name . '"' . $required . ' /></label></p>';
     }
 
-    public static function handleSubmit(): void {
+    public static function handle_submit(): void {
         \check_ajax_referer( 'wpbn_form_' . ( isset( $_POST['wpbn_form_id'] ) ? absint( $_POST['wpbn_form_id'] ) : 0 ), 'wpbn_nonce' );
 
         $formId = isset( $_POST['wpbn_form_id'] ) ? absint( $_POST['wpbn_form_id'] ) : 0;
@@ -227,8 +227,8 @@ class FormShortcode {
         $amount   = isset( $params['amount'] ) ? (int) $params['amount'] : $amount;
         $currency = isset( $params['currency'] ) ? (string) $params['currency'] : $currency;
 
-        $provider  = ProviderFactory::paymentForForm( $formId );
-        $invoice   = $provider->createInvoice( $formId, $amount, $currency, $data );
+        $provider  = ProviderFactory::payment_for_form( $formId );
+        $invoice   = $provider->create_invoice( $formId, $amount, $currency, $data );
         $invoiceId = isset( $invoice['invoice_id'] ) ? (string) $invoice['invoice_id'] : '';
         $paymentUrl = isset( $invoice['payment_url'] ) ? (string) $invoice['payment_url'] : '';
 

--- a/wp-bitcoin-newsletter/src/Shortcode/FormShortcode.php
+++ b/wp-bitcoin-newsletter/src/Shortcode/FormShortcode.php
@@ -249,13 +249,11 @@ class FormShortcode {
             [ '%d' ]
         );
 
-        wp_send_json_success(
-            [
-                'invoice_id'    => $invoiceId,
-                'payment_url'   => add_query_arg( [ 'wpbn_invoice' => $invoiceId ], $paymentUrl ),
-                'subscriber_id' => $subscriberId,
-            ]
-        );
+        wp_send_json_success([
+            'invoice_id' => $invoiceId,
+            'payment_url' => $paymentUrl,
+            'subscriber_id' => $subscriberId,
+        ]);
     }
 }
 

--- a/wp-bitcoin-newsletter/src/Shortcode/FormShortcode.php
+++ b/wp-bitcoin-newsletter/src/Shortcode/FormShortcode.php
@@ -10,13 +10,23 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
+/**
+ * Shortcode renderer and AJAX handler for newsletter form.
+ */
 class FormShortcode {
+    /** Register shortcode and AJAX actions. */
     public static function register(): void {
         add_shortcode( 'coinsnap_newsletter_form', [ __CLASS__, 'render' ] );
         add_action( 'wp_ajax_wpbn_submit_form', [ __CLASS__, 'handle_submit' ] );
         add_action( 'wp_ajax_nopriv_wpbn_submit_form', [ __CLASS__, 'handle_submit' ] );
     }
 
+    /**
+     * Render the newsletter form.
+     *
+     * @param array $atts Shortcode attributes.
+     * @return string HTML output.
+     */
     public static function render( $atts ): string {
         $atts = shortcode_atts(
             [
@@ -80,6 +90,12 @@ class FormShortcode {
         return apply_filters( 'wpbn_form_html', $html, $postId );
     }
 
+    /**
+     * Build ordered form fields map from meta.
+     *
+     * @param array $fields Meta values.
+     * @return array Structured fields.
+     */
     private static function build_ordered_fields( array $fields ): array {
         $map       = [];
         $candidates = [
@@ -113,6 +129,12 @@ class FormShortcode {
         return $map;
     }
 
+    /**
+     * Render a single input/select field.
+     *
+     * @param array $field Field config.
+     * @return string HTML.
+     */
     private static function render_field( array $field ): string {
         $required     = $field['required'] ? ' required' : '';
         $requiredMark = $field['required'] ? ' <span class="required">*</span>' : '';
@@ -132,6 +154,7 @@ class FormShortcode {
         return '<p class="wpbn-field"><label>' . $label . $requiredMark . '<br /><input type="text" name="' . $name . '"' . $required . ' /></label></p>';
     }
 
+    /** Handle AJAX form submission. */
     public static function handle_submit(): void {
         \check_ajax_referer( 'wpbn_form_' . ( isset( $_POST['wpbn_form_id'] ) ? absint( $_POST['wpbn_form_id'] ) : 0 ), 'wpbn_nonce' );
 

--- a/wp-bitcoin-newsletter/src/Util/ProviderFactory.php
+++ b/wp-bitcoin-newsletter/src/Util/ProviderFactory.php
@@ -13,15 +13,13 @@ use WpBitcoinNewsletter\Providers\Newsletter\MailchimpProvider;
 use WpBitcoinNewsletter\Providers\Newsletter\SendinblueProvider;
 use WpBitcoinNewsletter\Providers\Newsletter\ConvertKitProvider;
 
-class ProviderFactory
-{
-    public static function paymentForForm(int $formId): PaymentProviderInterface
-    {
+class ProviderFactory {
+    public static function paymentForForm( int $formId ): PaymentProviderInterface {
         $settings = Settings::getSettings();
-        $payment = get_post_meta($formId, '_wpbn_payment', true);
-        $override = is_array($payment) && !empty($payment['provider_override']) ? $payment['provider_override'] : '';
-        $key = $override ?: $settings['payment_provider'];
-        switch ($key) {
+        $payment  = get_post_meta( $formId, '_wpbn_payment', true );
+        $override = is_array( $payment ) && ! empty( $payment['provider_override'] ) ? $payment['provider_override'] : '';
+        $key      = $override ?: $settings['payment_provider'];
+        switch ( $key ) {
             case 'btcpay':
                 return new BTCPayProvider();
             case 'coinsnap':
@@ -30,13 +28,12 @@ class ProviderFactory
         }
     }
 
-    public static function newsletter(int $formId = 0): NewsletterProviderInterface
-    {
-        $settings = Settings::getSettings();
-        $providerMeta = $formId ? get_post_meta($formId, '_wpbn_provider', true) : [];
-        $override = is_array($providerMeta) && !empty($providerMeta['provider_override']) ? $providerMeta['provider_override'] : '';
-        $key = $override ?: $settings['newsletter_provider'];
-        switch ($key) {
+    public static function newsletter( int $formId = 0 ): NewsletterProviderInterface {
+        $settings     = Settings::getSettings();
+        $providerMeta = $formId ? get_post_meta( $formId, '_wpbn_provider', true ) : [];
+        $override     = is_array( $providerMeta ) && ! empty( $providerMeta['provider_override'] ) ? $providerMeta['provider_override'] : '';
+        $key          = $override ?: $settings['newsletter_provider'];
+        switch ( $key ) {
             case 'mailpoet':
                 return new MailPoetProvider();
             case 'mailchimp':

--- a/wp-bitcoin-newsletter/src/Util/ProviderFactory.php
+++ b/wp-bitcoin-newsletter/src/Util/ProviderFactory.php
@@ -13,7 +13,16 @@ use WpBitcoinNewsletter\Providers\Newsletter\MailchimpProvider;
 use WpBitcoinNewsletter\Providers\Newsletter\SendinblueProvider;
 use WpBitcoinNewsletter\Providers\Newsletter\ConvertKitProvider;
 
+/**
+ * Factory to resolve payment and newsletter provider implementations.
+ */
 class ProviderFactory {
+    /**
+     * Resolve payment provider for a given form.
+     *
+     * @param int $formId Form ID.
+     * @return PaymentProviderInterface Provider instance.
+     */
     public static function payment_for_form( int $formId ): PaymentProviderInterface {
         $settings = Settings::getSettings();
         $payment  = get_post_meta( $formId, '_wpbn_payment', true );
@@ -28,6 +37,12 @@ class ProviderFactory {
         }
     }
 
+    /**
+     * Resolve newsletter provider (optionally by form override).
+     *
+     * @param int $formId Optional form ID for override.
+     * @return NewsletterProviderInterface Provider instance.
+     */
     public static function newsletter( int $formId = 0 ): NewsletterProviderInterface {
         $settings     = Settings::getSettings();
         $providerMeta = $formId ? get_post_meta( $formId, '_wpbn_provider', true ) : [];

--- a/wp-bitcoin-newsletter/src/Util/ProviderFactory.php
+++ b/wp-bitcoin-newsletter/src/Util/ProviderFactory.php
@@ -14,7 +14,7 @@ use WpBitcoinNewsletter\Providers\Newsletter\SendinblueProvider;
 use WpBitcoinNewsletter\Providers\Newsletter\ConvertKitProvider;
 
 class ProviderFactory {
-    public static function paymentForForm( int $formId ): PaymentProviderInterface {
+    public static function payment_for_form( int $formId ): PaymentProviderInterface {
         $settings = Settings::getSettings();
         $payment  = get_post_meta( $formId, '_wpbn_payment', true );
         $override = is_array( $payment ) && ! empty( $payment['provider_override'] ) ? $payment['provider_override'] : '';

--- a/wp-bitcoin-newsletter/wp-bitcoin-newsletter.php
+++ b/wp-bitcoin-newsletter/wp-bitcoin-newsletter.php
@@ -53,7 +53,6 @@ add_action(
             require_once WPBN_PLUGIN_DIR . 'src/Plugin.php';
         }
         \WpBitcoinNewsletter\Plugin::instance()->boot();
-        add_action( 'template_redirect', [ \WpBitcoinNewsletter\Plugin::instance(), 'simulate_payment' ] );
     }
 );
 

--- a/wp-bitcoin-newsletter/wp-bitcoin-newsletter.php
+++ b/wp-bitcoin-newsletter/wp-bitcoin-newsletter.php
@@ -1,5 +1,10 @@
 <?php
-declare(strict_types=1);
+/**
+ * Main plugin loader.
+ *
+ * @package wp-bitcoin-newsletter
+ */
+
 /**
  * Plugin Name: WP Bitcoin Newsletter (Pay-per-Subscribe)
  * Description: Newsletter subscriptions are processed only after successful Bitcoin Lightning payment. Supports multiple newsletter providers and subscriber management.
@@ -12,6 +17,8 @@ declare(strict_types=1);
  *
  * @package wp-bitcoin-newsletter
  */
+
+declare(strict_types=1);
 
 if ( ! defined( 'ABSPATH' ) ) {
     exit;

--- a/wp-bitcoin-newsletter/wp-bitcoin-newsletter.php
+++ b/wp-bitcoin-newsletter/wp-bitcoin-newsletter.php
@@ -5,42 +5,55 @@
  * Version: 0.1.0
  * Author: Your Company
  * Text Domain: wpbn
+ * License: GPL-2.0-or-later
+ * Requires at least: 5.8
+ * Requires PHP: 7.4
  */
 
-defined('ABSPATH') || exit;
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
 
-define('WPBN_VERSION', '0.1.0');
-define('WPBN_PLUGIN_FILE', __FILE__);
-define('WPBN_PLUGIN_DIR', plugin_dir_path(__FILE__));
-define('WPBN_PLUGIN_URL', plugin_dir_url(__FILE__));
+define( 'WPBN_VERSION', '0.1.0' );
+define( 'WPBN_PLUGIN_FILE', __FILE__ );
+define( 'WPBN_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+define( 'WPBN_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
-// Simple PSR-4 autoloader for this plugin namespace
-spl_autoload_register(function ($class) {
-    $prefix = 'WpBitcoinNewsletter\\';
-    if (strpos($class, $prefix) !== 0) {
-        return;
+// Simple PSR-4 autoloader for this plugin namespace.
+spl_autoload_register(
+    function ( $class ) {
+        $prefix = 'WpBitcoinNewsletter\\';
+        if ( strpos( $class, $prefix ) !== 0 ) {
+            return;
+        }
+        $relative = substr( $class, strlen( $prefix ) );
+        $file     = WPBN_PLUGIN_DIR . 'src/' . str_replace( '\\', '/', $relative ) . '.php';
+        if ( file_exists( $file ) ) {
+            require_once $file;
+        }
     }
-    $relative = substr($class, strlen($prefix));
-    $file = WPBN_PLUGIN_DIR . 'src/' . str_replace('\\', '/', $relative) . '.php';
-    if (file_exists($file)) {
-        require_once $file;
-    }
-});
+);
 
-// Activation: create database tables
-register_activation_hook(__FILE__, function () {
-    if (!class_exists('WpBitcoinNewsletter\\Database\\Installer')) {
-        require_once WPBN_PLUGIN_DIR . 'src/Database/Installer.php';
+// Activation: create database tables.
+register_activation_hook(
+    __FILE__,
+    function () {
+        if ( ! class_exists( 'WpBitcoinNewsletter\\Database\\Installer' ) ) {
+            require_once WPBN_PLUGIN_DIR . 'src/Database/Installer.php';
+        }
+        \WpBitcoinNewsletter\Database\Installer::activate();
     }
-    \WpBitcoinNewsletter\Database\Installer::activate();
-});
+);
 
-// Bootstrap plugin after all plugins loaded
-add_action('plugins_loaded', function () {
-    if (!class_exists('WpBitcoinNewsletter\\Plugin')) {
-        require_once WPBN_PLUGIN_DIR . 'src/Plugin.php';
+// Bootstrap plugin after all plugins loaded.
+add_action(
+    'plugins_loaded',
+    function () {
+        if ( ! class_exists( 'WpBitcoinNewsletter\\Plugin' ) ) {
+            require_once WPBN_PLUGIN_DIR . 'src/Plugin.php';
+        }
+        \WpBitcoinNewsletter\Plugin::instance()->boot();
+        add_action( 'template_redirect', [ \WpBitcoinNewsletter\Plugin::instance(), 'simulatePayment' ] );
     }
-    \WpBitcoinNewsletter\Plugin::instance()->boot();
-    add_action('template_redirect', [\WpBitcoinNewsletter\Plugin::instance(), 'simulatePayment']);
-});
+);
 

--- a/wp-bitcoin-newsletter/wp-bitcoin-newsletter.php
+++ b/wp-bitcoin-newsletter/wp-bitcoin-newsletter.php
@@ -19,7 +19,9 @@ define( 'WPBN_PLUGIN_FILE', __FILE__ );
 define( 'WPBN_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'WPBN_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
-// Simple PSR-4 autoloader for this plugin namespace.
+/**
+ * Register a simple PSR-4 autoloader for this plugin namespace.
+ */
 spl_autoload_register(
     function ( $class ) {
         $prefix = 'WpBitcoinNewsletter\\';
@@ -34,7 +36,9 @@ spl_autoload_register(
     }
 );
 
-// Activation: create database tables.
+/**
+ * Activation: create or update required database tables.
+ */
 register_activation_hook(
     __FILE__,
     function () {
@@ -45,7 +49,9 @@ register_activation_hook(
     }
 );
 
-// Bootstrap plugin after all plugins loaded.
+/**
+ * Bootstrap plugin after all plugins are loaded.
+ */
 add_action(
     'plugins_loaded',
     function () {

--- a/wp-bitcoin-newsletter/wp-bitcoin-newsletter.php
+++ b/wp-bitcoin-newsletter/wp-bitcoin-newsletter.php
@@ -53,7 +53,7 @@ add_action(
             require_once WPBN_PLUGIN_DIR . 'src/Plugin.php';
         }
         \WpBitcoinNewsletter\Plugin::instance()->boot();
-        add_action( 'template_redirect', [ \WpBitcoinNewsletter\Plugin::instance(), 'simulatePayment' ] );
+        add_action( 'template_redirect', [ \WpBitcoinNewsletter\Plugin::instance(), 'simulate_payment' ] );
     }
 );
 

--- a/wp-bitcoin-newsletter/wp-bitcoin-newsletter.php
+++ b/wp-bitcoin-newsletter/wp-bitcoin-newsletter.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * Plugin Name: WP Bitcoin Newsletter (Pay-per-Subscribe)
  * Description: Newsletter subscriptions are processed only after successful Bitcoin Lightning payment. Supports multiple newsletter providers and subscriber management.
@@ -8,6 +9,8 @@
  * License: GPL-2.0-or-later
  * Requires at least: 5.8
  * Requires PHP: 7.4
+ *
+ * @package wp-bitcoin-newsletter
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -23,12 +26,12 @@ define( 'WPBN_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
  * Register a simple PSR-4 autoloader for this plugin namespace.
  */
 spl_autoload_register(
-    function ( $class ) {
+    function ( $autoload_class ) {
         $prefix = 'WpBitcoinNewsletter\\';
-        if ( strpos( $class, $prefix ) !== 0 ) {
+        if ( strpos( $autoload_class, $prefix ) !== 0 ) {
             return;
         }
-        $relative = substr( $class, strlen( $prefix ) );
+        $relative = substr( $autoload_class, strlen( $prefix ) );
         $file     = WPBN_PLUGIN_DIR . 'src/' . str_replace( '\\', '/', $relative ) . '.php';
         if ( file_exists( $file ) ) {
             require_once $file;


### PR DESCRIPTION
Align the plugin codebase with WordPress Coding Standards (WPCS) and add a `phpcs.xml.dist` for linting.

---
<a href="https://cursor.com/background-agent?bcId=bc-717739d1-a315-43b8-85a5-062f585cff95">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-717739d1-a315-43b8-85a5-062f585cff95">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

